### PR TITLE
Feature: Setup poethepoet

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -60,4 +60,4 @@ jobs:
       run: poetry install
     - name: Test with pytest
       run: |
-        poetry run poe tests
+        poetry run poe test

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,10 +33,10 @@ jobs:
         poetry run isort -c .
     - name: Lint src with pylint
       run: |
-        poe lint-src
+        poetry run poe lint-src
     - name: Lint tests with pylint
       run: |
-        poe lint-tests
+        poetry run poe lint-tests
 
   test:
 
@@ -60,4 +60,4 @@ jobs:
       run: poetry install
     - name: Test with pytest
       run: |
-        poe tests
+        poetry run poe tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,10 +33,10 @@ jobs:
         poetry run isort -c .
     - name: Lint src with pylint
       run: |
-        poetry run pylint src --rcfile ./.github/workflows/.pylintrcsrc
+        poe lint-src
     - name: Lint tests with pylint
       run: |
-        poetry run pylint tests --rcfile ./.github/workflows/.pylintrctests
+        poe lint-tests
 
   test:
 
@@ -60,4 +60,4 @@ jobs:
       run: poetry install
     - name: Test with pytest
       run: |
-        poetry run pytest
+        poe tests

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # bp2022-ap1
+
+## poe
+
+We define with `poe` some handy commands for development. Please take a look at the documentation in the [wiki](https://github.com/BP2022-AP1/bp2022-ap1/wiki#poe)

--- a/poetry.lock
+++ b/poetry.lock
@@ -258,6 +258,18 @@ files = [
 ]
 
 [[package]]
+name = "pastel"
+version = "0.2.1"
+description = "Bring colors to your terminal."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
+    {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
+]
+
+[[package]]
 name = "pathspec"
 version = "0.11.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -300,6 +312,25 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "poethepoet"
+version = "0.19.0"
+description = "A task runner that works well with poetry."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "poethepoet-0.19.0-py3-none-any.whl", hash = "sha256:87038be589077e4b407050a9da644d9cd9e4076ccfc8abc7f855cf6870d5c6c2"},
+    {file = "poethepoet-0.19.0.tar.gz", hash = "sha256:897eb85ec15876d79befc7d19d4c80ce7c8b214d1bb0dcfec640abd81616bfed"},
+]
+
+[package.dependencies]
+pastel = ">=0.2.1,<0.3.0"
+tomli = ">=1.2.2"
+
+[package.extras]
+poetry-plugin = ["poetry (>=1.0,<2.0)"]
 
 [[package]]
 name = "pylint"
@@ -506,4 +537,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "95aa21fc5c7fef4c0e076ba4185c2cb58473a6c08cdb94d388597f1547958e49"
+content-hash = "7db720ac201747488a2473fbf2748ba1ef69c7ec26e6a3d6c0472179bfcd9b4d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,23 @@ build-backend = "poetry.core.masonry.api"
     [tool.poe.tasks.format]
     help = "Run formating tools on the code base"
     sequence  = ["format-isort", "format-black"]
+
+    [tool.poe.tasks.lint-src]
+    help = "Run lint in /src directory"
+    cmd  = "pylint src --rcfile ./.github/workflows/.pylintrcsrc"
+
+    [tool.poe.tasks.lint-tests]
+    help = "Run lint in /tests directory"
+    cmd  = "pylint tests --rcfile ./.github/workflows/.pylintrctests"
+
+    [tool.poe.tasks.lint]
+    help = "Run lint in /src and /tests directory"
+    sequence  = ["lint-src", "lint-tests"]
+
+    [tool.poe.tasks.test]
+    help = "Run test with pytest"
+    cmd = "pytest"
+
+    [tool.poe.tasks.ci]
+    help = "Run formatting, linting and testing in preparation for CI"
+    sequence = ["format", "lint", "test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,17 @@ poethepoet = "^0.19.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poe.tasks]
+
+    [tool.poe.tasks.format-isort]
+    help = "Run isort on the code base"
+    cmd  = "isort ."
+
+    [tool.poe.tasks.format-black]
+    help = "Run black on the code base"
+    cmd  = "black ."
+
+    [tool.poe.tasks.format]
+    help = "Run formating tools on the code base"
+    sequence  = ["format-isort", "format-black"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pytest = "^7.2.2"
 black = "^23.1.0"
 isort = "^5.12.0"
 pylint = "^2.17.0"
+poethepoet = "^0.19.0"
 
 
 [build-system]


### PR DESCRIPTION
Fixes #68 

This PR installs `poethepoet` in order to run command line commands quickly.
It adds the command `poe format` to run `black` and `isort`.

You can find the new wiki entry here: https://github.com/nat-n/poethepoet

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] ~Breaking changes anounced~
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
