### PR TITLE
Adapt spawn restrictor interface in TrainCancelledFault

### DIFF
--- a/src/fault_injector/fault_types/train_cancelled_fault.py
+++ b/src/fault_injector/fault_types/train_cancelled_fault.py
@@ -1,11 +1,14 @@
 from src.component import Component
 from src.fault_injector.fault_types.fault import Fault, FaultConfig
+from src.interfaces import *
 
 
 class TrainCancelledFault(Fault):
     """A fault that blocks a platform"""
 
-    def inject_fault(self, component: Component):
+    affected_element_ID: int = None
+
+    def inject_fault(self, spawn_restrictor: ISpawnerRestrictor):
         """inject TrainCancelledFault into the given component
 
         :param component: The component the fault should be injected into
@@ -13,12 +16,12 @@ class TrainCancelledFault(Fault):
         """
         # - get train by id
         # - mark train as cancelled
-        raise NotImplementedError()
+        spawn_restrictor.block_schedule(self.affected_element_ID)
 
-    def resolve_fault(self, component: Component):
+    def resolve_fault(self, spawn_restrictor: ISpawnerRestrictor):
         """resolves the previously injected TrainCancelledFault
 
         :param component: the component with the injected fault
         :type component: Component
         """
-        raise NotImplementedError()
+        spawn_restrictor.unblock_schedule(self.affected_element_ID)


### PR DESCRIPTION
Fixes #124

Description (what might a PO or reviewer want to know?)
Uses the interface provided by the Spawner to block and unblock schedules in the inject_fault and resolve_fault methods

## PR checklist

- [x] Acceptance criteria fulfilled
- [ ] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
