### PR TITLE
Add IInterlockingDisruptor

### DIFF
--- a/src/interlocking_component/route_controller.py
+++ b/src/interlocking_component/route_controller.py
@@ -17,56 +17,56 @@ class RouteController(Component):
 class IInterlockingDisruptor:
     """This class is the Interface to inject faults into the interlocking as well as to notify the Interlocking faults that occur in other parts of the simulation."""
 
-    def insertTrackBlocked(self, track: track):
+    def insertTrackBlocked(self, track_id: str):
         """This method is used to block a track and recalculate the routes of relevant trains.
 
-        :param track: the blocked track
-        :type track: track (as a simulation_object)
+        :param track_id: the id of the blocked track
+        :type track_id: str
         :raises NotImplementedError: This has not yet been implemented.
         """
         raise NotImplementedError()
 
-    def insertTrackNotBlocked(self, track: track):
+    def insertTrackUnblocked(self, track_id: str):
         """This method is used to unblock a track and recalculate the routes of relevant trains.
 
-        :param track: the unblocked track
-        :type track: track (as a simulation_object)
+        :param track_id: the id of the unblocked track
+        :type track_id: str
         :raises NotImplementedError: This has not yet been implemented.
         """
         raise NotImplementedError()
 
-    def insertPlatformBlocked(self, platform: platform):
+    def insertPlatformBlocked(self, platform_id: str):
         """This method is used to block a platform and recalculate the routes and stops of relevant trains.
 
-        :param platform: the blocked platform
-        :type platform: platform (as a simulation_object)
+        :param platform_id: the id of the blocked platform
+        :type platform_id: str
         :raises NotImplementedError: This has not yet been implemented.
         """
         raise NotImplementedError()
 
-    def insertPlatformNotBlocked(self, platform: platform):
+    def insertPlatformUnblocked(self, platform_id: str):
         """This method is used to unblock a platform and recalculate the routes and stops of relevant trains.
 
-        :param platform: the unblocked platform
-        :type platform: platform (as a simulation_object)
+        :param platform_id: the id of the unblocked platform
+        :type platform_id: str
         :raises NotImplementedError: This has not yet been implemented.
         """
         raise NotImplementedError()
 
-    def insertTrackSpeedLimitChanged(self, track: track):
+    def insertTrackSpeedLimitChanged(self, track_id: str):
         """This method is used to notify the interlocking about a changed track speed limit, so that it can recalculate the routing of relevant trains.
 
-        :param track: the track, which speedlimit changed
-        :type track: track (as a simulation_object)
+        :param track_id: the id of the track, which speedlimit changed
+        :type track_id: str
         :raises NotImplementedError: This has not yet been implemented.
         """
         raise NotImplementedError()
 
-    def insertTrainSpeedChanged(self, train: train):
+    def insertTrainSpeedChanged(self, train_id: str):
         """This method is used to notify the interlocking about a changed train speed limit, so that it can recalculate the routing of relevant trains.
 
-        :param train: the train, which speed limit changed
-        :type train: train (as a simulation_object)
+        :param train_id: the id of the train, which speed limit changed
+        :type train_id: str
         :raises NotImplementedError: This has not yet been implemented.
         """
         raise NotImplementedError()

--- a/src/interlocking_component/route_controller.py
+++ b/src/interlocking_component/route_controller.py
@@ -12,3 +12,61 @@ class RouteController(Component):
         :raises NotImplementedError: This has not yet been implemented.
         """
         raise NotImplementedError()
+
+
+class IInterlockingDisruptor:
+    """This class is the Interface to inject faults into the interlocking as well as to notify the Interlocking faults that occur in other parts of the simulation."""
+
+    def insertTrackBlocked(self, track: track):
+        """This method is used to block a track and recalculate the routes of relevant trains.
+
+        :param track: the blocked track
+        :type track: track (as a simulation_object)
+        :raises NotImplementedError: This has not yet been implemented.
+        """
+        raise NotImplementedError()
+
+    def insertTrackNotBlocked(self, track: track):
+        """This method is used to unblock a track and recalculate the routes of relevant trains.
+
+        :param track: the unblocked track
+        :type track: track (as a simulation_object)
+        :raises NotImplementedError: This has not yet been implemented.
+        """
+        raise NotImplementedError()
+
+    def insertPlatformBlocked(self, platform: platform):
+        """This method is used to block a platform and recalculate the routes and stops of relevant trains.
+
+        :param platform: the blocked platform
+        :type platform: platform (as a simulation_object)
+        :raises NotImplementedError: This has not yet been implemented.
+        """
+        raise NotImplementedError()
+
+    def insertPlatformNotBlocked(self, platform: platform):
+        """This method is used to unblock a platform and recalculate the routes and stops of relevant trains.
+
+        :param platform: the unblocked platform
+        :type platform: platform (as a simulation_object)
+        :raises NotImplementedError: This has not yet been implemented.
+        """
+        raise NotImplementedError()
+
+    def insertTrackSpeedLimitChanged(self, track: track):
+        """This method is used to notify the interlocking about a changed track speed limit, so that it can recalculate the routing of relevant trains.
+
+        :param track: the track, which speedlimit changed
+        :type track: track (as a simulation_object)
+        :raises NotImplementedError: This has not yet been implemented.
+        """
+        raise NotImplementedError()
+
+    def insertTrainSpeedChanged(self, train: train):
+        """This method is used to notify the interlocking about a changed train speed limit, so that it can recalculate the routing of relevant trains.
+
+        :param train: the train, which speed limit changed
+        :type train: train (as a simulation_object)
+        :raises NotImplementedError: This has not yet been implemented.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
Fixes #90 

This adds the Interface for the fault injector to minpulate and notify the interlocking. Not all of the methods have consequences for the state of the interlocking, but they can be used to reroute trains.

There are methods for all relevant fault_types defined in the [fault injector architecture](https://github.com/BP2022-AP1/bp2022-ap1/wiki/Architecture#faultinjector).

## PR checklist

- [ ] Acceptance criteria fulfilled
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
