### PR TITLE
Fix: replace __subclasses__ class with constant

### DIFF
--- a/db/local/db.py
+++ b/db/local/db.py
@@ -1,15 +1,13 @@
 import argparse
 import os
 import subprocess
-from typing import Type
 
 from peewee_migrate import Router
 
-from src.base_model import BaseModel, db
+from src.base_model import db
+from src.constants import tables
 
 MIGRATION_DIRECTORY: str = "db/local/migrations"
-
-models: list[Type[BaseModel]] = BaseModel.__subclasses__()
 
 
 def run(args: argparse.Namespace):
@@ -58,13 +56,13 @@ def stop(args: argparse.Namespace):
 
 def create(_: argparse.Namespace):
     """Create database tables"""
-    db.create_tables(models)
+    db.create_tables(tables)
     print("Created tables")
 
 
 def drop(_: argparse.Namespace):
     """Drop database tables"""
-    db.drop_tables(models)
+    db.drop_tables(tables)
     print("Dropped tables")
 
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,6 @@
+from typing import Type
+
+from src.base_model import BaseModel
+
+# Add classes that should be created as tables to this list
+tables: list[Type[BaseModel]] = []


### PR DESCRIPTION
Fixes #149 

Replace __subclasses__ call with constant list containing needed tables.
Moves into own file to prevent circular imports.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
