### PR TITLE
Feature/180 test db decorator

### DIFF
--- a/tests/db/test_db.py
+++ b/tests/db/test_db.py
@@ -4,7 +4,7 @@ import marshmallow as marsh
 from peewee import IntegerField
 
 from src.base_model import BaseModel, db
-from tests.decorators import recreate_db
+from tests.decorators import recreate_db_setup
 
 
 class ModelTest(BaseModel):
@@ -28,7 +28,7 @@ class ModelTest(BaseModel):
 class TestDB:
     """Test the database connection and the serialization/deserialization"""
 
-    @recreate_db
+    @recreate_db_setup
     def setup_method(self):
         db.create_tables([ModelTest])
 

--- a/tests/db/test_db.py
+++ b/tests/db/test_db.py
@@ -4,6 +4,7 @@ import marshmallow as marsh
 from peewee import IntegerField
 
 from src.base_model import BaseModel, db
+from tests.decorators import recreate_db
 
 
 class ModelTest(BaseModel):
@@ -27,6 +28,7 @@ class ModelTest(BaseModel):
 class TestDB:
     """Test the database connection and the serialization/deserialization"""
 
+    @recreate_db
     def setup_method(self):
         db.create_tables([ModelTest])
 

--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -1,0 +1,22 @@
+from functools import wraps
+from typing import Callable
+
+from src.base_model import db
+from src.constants import tables
+
+
+def recreate_db(func: Callable):
+    """Decorates a function and will recreate the database
+    before calling the function.
+
+    :param func: The function to decorate
+    :return: The decorated function
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        db.drop_tables(tables)
+        db.create_tables(tables)
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -6,11 +6,11 @@ from src.constants import tables
 
 
 def recreate_db(func: Callable):
-    """Decorates a function and will recreate the database
+    """Decorates a test function and will recreate the database
     before calling the function.
 
-    :param func: The function to decorate
-    :return: The decorated function
+    :param func: The test function to decorate
+    :return: The decorated test function
     """
 
     @wraps(func)
@@ -18,5 +18,22 @@ def recreate_db(func: Callable):
         db.drop_tables(tables)
         db.create_tables(tables)
         return func(*args, **kwargs)
+
+    return wrapper
+
+
+def recreate_db_setup(func: Callable):
+    """Decorates a test setup function and will recreate the database
+    before calling the function.
+
+    :param func: The test setup function to decorate
+    :return: The decorated test setup function
+    """
+
+    @wraps(func)
+    def wrapper(method: Callable, *args, **kwargs):
+        db.drop_tables(tables)
+        db.create_tables(tables)
+        return func(method, *args, **kwargs)
 
     return wrapper

--- a/tests/schedule/test_regular_schedule_strategy.py
+++ b/tests/schedule/test_regular_schedule_strategy.py
@@ -3,6 +3,7 @@ from typing import Callable
 import pytest
 
 from src.schedule.regular_schedule_strategy import RegularScheduleStrategy
+from tests.decorators import recreate_db
 
 
 class TestRegularScheduleStrategy:
@@ -66,6 +67,7 @@ class TestRegularScheduleStrategy:
         assert regular_strategy.start_tick == deserialized.start_tick
         assert regular_strategy.frequency == deserialized.frequency
 
+    @recreate_db
     def test_database_interaction(
         self, regular_strategy: Callable[[None], RegularScheduleStrategy]
     ):


### PR DESCRIPTION
Fixes #180

We now have decorators `recreate_db` and `recreate_db_setup` which are defined in `tests/decorators.py`.

Put `recreate_db` in front of a test function to recreate the db before its execution like this:
```python
from tests.decorators import recreate_db

@recreate_db
def test_function():
    assert True
```

Put `recreate_db_setup` in front of test setup functions like that:
```python
from tests.decorators import recreate_db_setup

class TestClass:

    @recreate_db_setup
    def setup_method(self):
        pass

    def test_method(self):
        # db will be recreated here
        assert True
```

## PR checklist

- [x] Acceptance criteria fulfilled
- [ ] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
