### PR TITLE
Feature: Add foreign keys between `SimulationConfiguration`, `Run` and `Token`

### DIFF
--- a/src/implementor/models.py
+++ b/src/implementor/models.py
@@ -4,20 +4,6 @@ from peewee import CharField
 from src.base_model import BaseModel
 
 
-class SimulationConfiguration(BaseModel):
-    """Represents a single simulation configuration."""
-
-    class Schema(BaseModel.Schema):
-        """The marshmallow schema for the simulation configuration model."""
-
-        description = marsh.fields.String()
-
-        def _make(self, data: dict) -> "SimulationConfiguration":
-            return SimulationConfiguration(**data)
-
-    description = CharField(null=True)
-
-
 class Token(BaseModel):
     """Represents a token."""
 
@@ -34,6 +20,20 @@ class Token(BaseModel):
     permission = CharField()
     name = CharField()
     hashedToken = CharField()
+
+
+class SimulationConfiguration(BaseModel):
+    """Represents a single simulation configuration."""
+
+    class Schema(BaseModel.Schema):
+        """The marshmallow schema for the simulation configuration model."""
+
+        description = marsh.fields.String()
+
+        def _make(self, data: dict) -> "SimulationConfiguration":
+            return SimulationConfiguration(**data)
+
+    description = CharField(null=True)
 
 
 class Run(BaseModel):

--- a/src/implementor/models.py
+++ b/src/implementor/models.py
@@ -1,5 +1,5 @@
 import marshmallow as marsh
-from peewee import CharField
+from peewee import CharField, ForeignKeyField
 
 from src.base_model import BaseModel
 
@@ -29,11 +29,13 @@ class SimulationConfiguration(BaseModel):
         """The marshmallow schema for the simulation configuration model."""
 
         description = marsh.fields.String()
+        token = marsh.fields.UUID(required=True)
 
         def _make(self, data: dict) -> "SimulationConfiguration":
             return SimulationConfiguration(**data)
 
     description = CharField(null=True)
+    token = ForeignKeyField(Token, backref="simulation_configurations")
 
 
 class Run(BaseModel):

--- a/src/implementor/models.py
+++ b/src/implementor/models.py
@@ -46,3 +46,7 @@ class Run(BaseModel):
 
         def _make(self, data: dict) -> "Run":
             return Run(**data)
+
+        simulation_configuration = marsh.fields.UUID(required=True)
+
+    simulation_configuration = ForeignKeyField(SimulationConfiguration, backref="runs")

--- a/tests/implementor/test_table_run.py
+++ b/tests/implementor/test_table_run.py
@@ -4,14 +4,10 @@ import marshmallow as marsh
 import peewee
 import pytest
 
-from src.implementor.models import Run
+from src.implementor.models import Run, SimulationConfiguration, Token
 from tests.decorators import recreate_db_setup
 
 
-@pytest.mark.parametrize(
-    "init_dict",
-    [],
-)
 class TestRunFailingInit:
     """Test that a object of a class cannot be created or deserialized with invalid data."""
 
@@ -19,11 +15,26 @@ class TestRunFailingInit:
     def setup_method(self):
         pass
 
+    @pytest.mark.parametrize(
+        "init_dict",
+        [
+            {  # simulation_configuration does not exists
+                "simulation_configuration": "00000000-0000-0000-0000-000000000000",
+            },
+            {},  # simulation_configuration is missing
+        ],
+    )
     def test_create(self, init_dict: dict):
         """Test that an object of a class cannot be saved."""
         with pytest.raises(peewee.IntegrityError):
             Run(**init_dict).save(force_insert=True)
 
+    @pytest.mark.parametrize(
+        "init_dict",
+        [
+            {},  # simulation_configuration is missing
+        ],
+    )
     def test_deserialization(self, init_dict: dict):
         """Test that an object of a class cannot be deserialized."""
         with pytest.raises(marsh.exceptions.ValidationError):
@@ -37,20 +48,37 @@ class TestRunSuccessfulInit:
     def setup_method(self):
         pass
 
+    @pytest.fixture
+    def token(self):
+        token = Token(name="owner", permission="admin", hashedToken="hash")
+        token.save()
+        return token
+
+    @pytest.fixture
+    def simulation_configuration(self, token):
+        simulation_configuration = SimulationConfiguration(token=token.id)
+        simulation_configuration.save()
+        return simulation_configuration
+
     @pytest.mark.parametrize(
         "init_dict",
         [
             {},
         ],
     )
-    def test_create(self, init_dict: dict):
+    def test_create(
+        self, init_dict: dict, simulation_configuration: SimulationConfiguration
+    ):
         """Test that a object of a class can be created."""
         obj = Run(
             **init_dict,
+            simulation_configuration=simulation_configuration.id,
         )
         obj.save(force_insert=True)
         assert isinstance(obj, Run)
         assert isinstance(obj.id, UUID)
+        assert isinstance(obj.simulation_configuration, SimulationConfiguration)
+        assert obj.simulation_configuration == simulation_configuration
         assert Run.select().where(Run.id == obj.id).first() == obj
 
     # pylint: disable=duplicate-code
@@ -61,13 +89,23 @@ class TestRunSuccessfulInit:
             ({}, {}),
         ],
     )
-    def test_serialization(self, init_values: dict, expected_dict: dict):
+    def test_serialization(
+        self,
+        init_values: dict,
+        expected_dict: dict,
+        simulation_configuration: SimulationConfiguration,
+    ):
         """Test that an object of a class can be serialized."""
         obj = Run(
             **init_values,
+            simulation_configuration=simulation_configuration.id,
         )
         serialized_obj = obj.to_dict()
         assert isinstance(serialized_obj["id"], str)
+        assert isinstance(serialized_obj["simulation_configuration"], str)
+        assert serialized_obj["simulation_configuration"] == str(
+            simulation_configuration.id
+        )
         for key in expected_dict.keys():
             assert serialized_obj[key] == expected_dict[key]
 
@@ -77,13 +115,20 @@ class TestRunSuccessfulInit:
             ({}, {}),
         ],
     )
-    def test_deserialization(self, init_dict: dict, expected_values: dict):
+    def test_deserialization(
+        self,
+        init_dict: dict,
+        expected_values: dict,
+        simulation_configuration: SimulationConfiguration,
+    ):
         """Test that an object of a class can be deserialized."""
         obj = Run.Schema().load(
-            init_dict,
+            {**init_dict, "simulation_configuration": simulation_configuration.id}
         )
         assert isinstance(obj, Run)
         assert isinstance(obj.id, UUID)
+        assert isinstance(obj.simulation_configuration, SimulationConfiguration)
+        assert obj.simulation_configuration == simulation_configuration
         for key in expected_values.keys():
             assert getattr(obj, key) == expected_values[key]
 

--- a/tests/implementor/test_table_simulation_configuration.py
+++ b/tests/implementor/test_table_simulation_configuration.py
@@ -4,14 +4,10 @@ import marshmallow as marsh
 import peewee
 import pytest
 
-from src.implementor.models import SimulationConfiguration
+from src.implementor.models import SimulationConfiguration, Token
 from tests.decorators import recreate_db_setup
 
 
-@pytest.mark.parametrize(
-    "init_dict",
-    [],
-)
 class TestSimulationConfigurationFailingInit:
     """Test that a object of a class cannot be created or deserialized with invalid data."""
 
@@ -19,11 +15,26 @@ class TestSimulationConfigurationFailingInit:
     def setup_method(self):
         pass
 
+    @pytest.mark.parametrize(
+        "init_dict",
+        [
+            {  # token does not exists
+                "token": "00000000-0000-0000-0000-000000000000",
+            },
+            {},  # token is missing
+        ],
+    )
     def test_create(self, init_dict: dict):
         """Test that an object of a class cannot be saved."""
         with pytest.raises(peewee.IntegrityError):
             SimulationConfiguration(**init_dict).save(force_insert=True)
 
+    @pytest.mark.parametrize(
+        "init_dict",
+        [
+            {},  # token is missing
+        ],
+    )
     def test_deserialization(self, init_dict: dict):
         """Test that an object of a class cannot be deserialized."""
         with pytest.raises(marsh.exceptions.ValidationError):
@@ -37,6 +48,12 @@ class TestSimulationConfigurationSuccessfulInit:
     def setup_method(self):
         pass
 
+    @pytest.fixture
+    def token(self):
+        token = Token(name="owner", permission="admin", hashedToken="hash")
+        token.save()
+        return token
+
     @pytest.mark.parametrize(
         "init_dict",
         [
@@ -46,14 +63,17 @@ class TestSimulationConfigurationSuccessfulInit:
             {},
         ],
     )
-    def test_create(self, init_dict: dict):
+    def test_create(self, init_dict: dict, token: Token):
         """Test that a object of a class can be created."""
         obj = SimulationConfiguration(
             **init_dict,
+            token=token.id,
         )
         obj.save(force_insert=True)
         assert isinstance(obj, SimulationConfiguration)
         assert isinstance(obj.id, UUID)
+        assert isinstance(obj.token, Token)
+        assert obj.token == token
         assert (
             SimulationConfiguration.select()
             .where(SimulationConfiguration.id == obj.id)
@@ -77,14 +97,17 @@ class TestSimulationConfigurationSuccessfulInit:
             ({}, {"description": None}),
         ],
     )
-    def test_serialization(self, init_values: dict, expected_dict: dict):
+    def test_serialization(self, init_values: dict, expected_dict: dict, token: Token):
         """Test that an object of a class can be serialized."""
         obj = SimulationConfiguration(
             **init_values,
+            token=token.id,
         )
 
         serialized_obj = obj.to_dict()
         assert isinstance(serialized_obj["id"], str)
+        assert isinstance(serialized_obj["token"], str)
+        assert serialized_obj["token"] == str(token.id)
         for key in expected_dict.keys():
             assert serialized_obj[key] == expected_dict[key]
 
@@ -102,13 +125,15 @@ class TestSimulationConfigurationSuccessfulInit:
             ({}, {"description": None}),
         ],
     )
-    def test_deserialization(self, init_dict: dict, expected_values: dict):
+    def test_deserialization(
+        self, init_dict: dict, expected_values: dict, token: Token
+    ):
         """Test that an object of a class can be deserialized."""
-        obj = SimulationConfiguration.Schema().load(
-            init_dict,
-        )
+        obj = SimulationConfiguration.Schema().load({**init_dict, "token": token.id})
         assert isinstance(obj, SimulationConfiguration)
         assert isinstance(obj.id, UUID)
+        assert isinstance(obj.token, Token)
+        assert obj.token == token
         for key in expected_values.keys():
             assert getattr(obj, key) == expected_values[key]
 

--- a/tests/logger/conftest.py
+++ b/tests/logger/conftest.py
@@ -30,18 +30,18 @@ def message():
     return "Test Log Done"
 
 
-@pytest.fixture
-def token():
+@pytest.fixture(name="token")
+def fixture_token():
     return Token.create(name="user", permission="admin", hashedToken="hash")
 
 
-@pytest.fixture
-def simulation_configuration(token):
+@pytest.fixture(name="simulation_configuration")
+def fixture_simulation_configuration(token):
     return SimulationConfiguration.create(token=token.id)
 
 
-@pytest.fixture
-def run(simulation_configuration):
+@pytest.fixture(name="run")
+def fixture_run(simulation_configuration):
     return Run.create(simulation_configuration=simulation_configuration.id)
 
 

--- a/tests/logger/conftest.py
+++ b/tests/logger/conftest.py
@@ -12,7 +12,7 @@ from src.fault_injector.fault_types.train_cancelled_fault import (
 from src.fault_injector.fault_types.train_speed_fault import (
     TrainSpeedFaultConfiguration,
 )
-from src.implementor.models import Run, Token, SimulationConfiguration
+from src.implementor.models import Run, SimulationConfiguration, Token
 
 
 @pytest.fixture

--- a/tests/logger/conftest.py
+++ b/tests/logger/conftest.py
@@ -12,7 +12,7 @@ from src.fault_injector.fault_types.train_cancelled_fault import (
 from src.fault_injector.fault_types.train_speed_fault import (
     TrainSpeedFaultConfiguration,
 )
-from src.implementor.models import Run
+from src.implementor.models import Run, Token, SimulationConfiguration
 
 
 @pytest.fixture
@@ -31,8 +31,18 @@ def message():
 
 
 @pytest.fixture
-def run():
-    return Run.create()
+def token():
+    return Token.create(name="user", permission="admin", hashedToken="hash")
+
+
+@pytest.fixture
+def simulation_configuration(token):
+    return SimulationConfiguration.create(token=token.id)
+
+
+@pytest.fixture
+def run(simulation_configuration):
+    return Run.create(simulation_configuration=simulation_configuration.id)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #224 

Add foreign keys from `Run` to `SimulationConfiguration` and `SimulationConfiguration` to `Token`.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
