### PR TITLE
Feature: Add autogenerated request collection

### DIFF
--- a/.postman/api_b23db1c0-fe6b-4c8f-887a-2c9ca66ebf20
+++ b/.postman/api_b23db1c0-fe6b-4c8f-887a-2c9ca66ebf20
@@ -9,6 +9,7 @@ id = b23db1c0-fe6b-4c8f-887a-2c9ca66ebf20
 
 [config.relations.collections]
 rootDirectory = postman/collections
+files[] = {"id":"21532014-ab891774-2446-4b42-bbc3-e3c61b3875d5","path":"rest-api-autogenerate.json","metaData":{"generateCollectionPreferences":"{\"requestNameSource\":\"URL\",\"indentCharacter\":\"Space\",\"parametersResolution\":\"Schema\",\"folderStrategy\":\"Paths\",\"includeAuthInfoInExample\":true,\"keepImplicitHeaders\":false,\"includeDeprecated\":true,\"updateCollectionSync\":true,\"requestParametersResolution\":\"Schema\",\"exampleParametersResolution\":\"Schema\"}"}}
 
 [config.relations.collections.metaData]
 

--- a/postman/collections/rest-api-autogenerate.json
+++ b/postman/collections/rest-api-autogenerate.json
@@ -1,0 +1,8325 @@
+{
+	"info": {
+		"_postman_id": "ab891774-2446-4b42-bbc3-e3c61b3875d5",
+		"name": "rest-api-autogenerate",
+		"description": "An API for simulation and analysis of train traffic on the LEAG rail network",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_uid": "21532014-ab891774-2446-4b42-bbc3-e3c61b3875d5"
+	},
+	"item": [
+		{
+			"name": "token",
+			"item": [
+				{
+					"name": "/token",
+					"id": "850f6e1b-39e0-4137-b741-94223070373d",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"permission\": \"<string>\"\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/token",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"token"
+							]
+						}
+					},
+					"response": [
+						{
+							"id": "06624d27-f1a8-413e-9b66-71fca70f09c3",
+							"name": "Successfully created new token",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"permission\": \"<string>\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/token",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"token"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{}"
+						},
+						{
+							"id": "90ccc0d8-7c7a-4b79-80f9-6368553b7a22",
+							"name": "API token missing",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"permission\": \"<string>\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/token",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"token"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						},
+						{
+							"id": "a78d6a98-9c18-41e4-921f-d7852bc44dff",
+							"name": "No rights to execute this action",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"permission\": \"<string>\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/token",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"token"
+									]
+								}
+							},
+							"status": "Forbidden",
+							"code": 403,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						}
+					]
+				}
+			],
+			"id": "72d82777-dc3d-4017-8c04-61487871bff5"
+		},
+		{
+			"name": "simulation",
+			"item": [
+				{
+					"name": "{id}",
+					"item": [
+						{
+							"name": "/simulation/:id",
+							"id": "b704906d-38f2-434d-a468-86cc24a93d06",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/simulation/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "6993b4c7-5a05-413b-b9e5-0f28aa5ad4fc",
+									"name": "Deleted simulation configuration",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "77673f02-ab45-4c3b-9f8a-060f27a0d4af",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "1adee0d7-dd34-4148-a122-dea1c658bf20",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/simulation/:id",
+							"id": "a602de61-8874-4110-9d87-0c32c85f3fc7",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/simulation/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "949f0a59-1a3a-4479-b989-eae30efb6719",
+									"name": "Successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								},
+								{
+									"id": "43e5aad0-9999-4200-9235-8a198396c146",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "47f832ba-709e-4977-99e2-141fda437704",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/simulation/:id",
+							"id": "b5b75b69-4964-457c-8d4b-36f46a4a786d",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/simulation/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "0582a77c-5949-45ef-ab95-18b971dd9257",
+									"name": "Updated simulation configuration",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "b74c21de-4cfb-48b7-a868-fd2df00f5a84",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "71cfd819-478b-41e4-9cd3-2f1cd30f05b5",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "68582095-2da4-482a-a224-6992fb2dafb8",
+									"name": "It's forbidden to edit an already ran simulation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Method Not Allowed",
+									"code": 405,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						}
+					],
+					"id": "2d1a3fa7-2fff-4510-a7a4-30c6253c96ad"
+				},
+				{
+					"name": "/simulation",
+					"id": "572cc7a4-e516-4a95-be62-f2d5952762a2",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/simulation",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"simulation"
+							]
+						}
+					},
+					"response": [
+						{
+							"id": "480d4815-c226-48f5-8b01-a12aa0476c6f",
+							"name": "Successful operation",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/simulation",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+						},
+						{
+							"id": "d399af7a-5120-426a-9153-30fed37900ad",
+							"name": "API token missing",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/simulation",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						}
+					]
+				},
+				{
+					"name": "/simulation",
+					"id": "ff040ada-2ec2-4be6-a079-1e62430e6550",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/simulation",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"simulation"
+							]
+						}
+					},
+					"response": [
+						{
+							"id": "3b8b06a2-2990-4e20-9c07-ca206612aa7d",
+							"name": "Successfully created new simulation configuration",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/simulation",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"id\": \"<uuid>\"\n}"
+						},
+						{
+							"id": "a6b20ee9-d13a-4a6f-b8fa-e078cb50bdd3",
+							"name": "API token missing",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/simulation",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						}
+					]
+				}
+			],
+			"id": "f331360f-a3a3-4093-8167-db04be369b4d"
+		},
+		{
+			"name": "schedule",
+			"item": [
+				{
+					"name": "{id}",
+					"item": [
+						{
+							"name": "/schedule/:id",
+							"id": "8e84264e-9d71-4375-9f8d-7a9a9e78cca5",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/schedule/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "9bc328f0-abd8-423a-bf6c-3d49254e0e1f",
+									"name": "Deleted schedule",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "d37f2a1f-8f8e-447e-b155-e4933377bcc6",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "4b1b8f8a-8dd3-4042-b8f7-106525b3c4bf",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/schedule/:id",
+							"id": "e46c7b08-2cce-4c27-a80f-74d81ed7f606",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/schedule/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "df70748b-e928-478d-95d0-b82462ccc079",
+									"name": "Successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								},
+								{
+									"id": "8af63875-953f-48d6-b26c-1c8da8e99d40",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "926f35b6-540f-4d17-ac0d-9b5fbadaaa29",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/schedule/:id",
+							"id": "fed780cb-5c3f-4948-9a74-fb50dfd5866a",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/schedule/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "85b55852-2387-4118-b3c0-d35a79959e01",
+									"name": "Updated schedule.",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "9a037614-f7f7-4994-b2a3-621c014b3683",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "384cc59d-3c62-4e04-b858-44212033cb31",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "647973a3-6160-48fb-a73e-4e08e3f2a431",
+									"name": "It's forbidden to edit an already ran simulation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/schedule/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"schedule",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Method Not Allowed",
+									"code": 405,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						}
+					],
+					"id": "0a3d88c8-2fd1-47b0-ae7c-7b30ac5e3a4b"
+				},
+				{
+					"name": "/schedule",
+					"id": "155da7d0-9375-44ff-b26e-bfd05868276c",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/schedule?simulationId=<uuid>",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"schedule"
+							],
+							"query": [
+								{
+									"description": "Specify id of simulation if you only want to get all schedules of a single simulation",
+									"key": "simulationId",
+									"value": "<uuid>"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"id": "141cabff-b6e9-4e99-b263-4761d0b49223",
+							"name": "Successful operation",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/schedule?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule"
+									],
+									"query": [
+										{
+											"description": "Specify id of simulation if you only want to get all schedules of a single simulation",
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+						},
+						{
+							"id": "9aa7e992-626e-491f-a8b1-84e775a63dbd",
+							"name": "API token missing",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/schedule?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule"
+									],
+									"query": [
+										{
+											"description": "Specify id of simulation if you only want to get all schedules of a single simulation",
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						},
+						{
+							"id": "b12dbb05-0195-44b4-83b4-4edfd7693462",
+							"name": "Simulation not found",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/schedule?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule"
+									],
+									"query": [
+										{
+											"description": "Specify id of simulation if you only want to get all schedules of a single simulation",
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						}
+					]
+				},
+				{
+					"name": "/schedule",
+					"id": "3dbce152-391d-4ae3-8bb6-f4c349210e70",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/schedule",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"schedule"
+							]
+						}
+					},
+					"response": [
+						{
+							"id": "1b8ba445-87ed-422a-9695-b81797b0c04e",
+							"name": "Successfully created new schedule object",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/schedule",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"id\": \"<uuid>\"\n}"
+						},
+						{
+							"id": "e0fd9b94-d9c7-48af-9ccd-e68b27395829",
+							"name": "API token missing",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/schedule",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"schedule"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						}
+					]
+				}
+			],
+			"id": "661e230b-406b-4066-8808-fcb48d44fdab"
+		},
+		{
+			"name": "run",
+			"item": [
+				{
+					"name": "{id}",
+					"item": [
+						{
+							"name": "/run/:id",
+							"id": "47e01ccf-8929-4d17-8f93-ff1434ebada7",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/run/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "5fee56c1-a48e-4c8a-b78f-ed8b0e7571d9",
+									"name": "Deleted simulation configuration",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/run/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"run",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "796fa472-3f14-4db3-a09f-958cf652fb65",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/run/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"run",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "82efd832-e47a-4328-b8ce-cfd69934003e",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/run/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"run",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/run/:id",
+							"id": "01cf3b36-84af-424d-8b93-8dc55f42cd4c",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/run/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "b30df9a9-3557-4e1b-af84-66a5243415c4",
+									"name": "Successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/run/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"run",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{}"
+								},
+								{
+									"id": "885e9f8b-0ad6-4559-8cf0-8f37dfcf0b46",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/run/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"run",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "a3f946eb-55af-460b-a11d-949ac9c3f99f",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/run/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"run",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						}
+					],
+					"id": "63f1bd44-c848-40ab-903b-d97ccac3f1bd"
+				},
+				{
+					"name": "/run",
+					"id": "1122a66f-ce86-476c-affd-83a2e1ac27f0",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/run?simulationId=<uuid>",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"run"
+							],
+							"query": [
+								{
+									"key": "simulationId",
+									"value": "<uuid>"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"id": "ed18b2dc-8e7b-40a1-9304-ca065959f950",
+							"name": "Successful operation",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/run?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run"
+									],
+									"query": [
+										{
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+						},
+						{
+							"id": "3094451b-6d4c-40dd-b394-49a2260e69c0",
+							"name": "API token missing",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/run?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run"
+									],
+									"query": [
+										{
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						},
+						{
+							"id": "4041a9a4-78dc-4c60-b06f-244ebf7fa5e9",
+							"name": "Simulation id not found",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/run?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run"
+									],
+									"query": [
+										{
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						}
+					]
+				},
+				{
+					"name": "/run",
+					"id": "8ca53558-102a-4ed0-a108-4b03f60228f4",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/run",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"run"
+							]
+						}
+					},
+					"response": [
+						{
+							"id": "76a0f612-e4e4-4c7e-87ca-6dae85fd03e3",
+							"name": "Successfully created and started a new run",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/run",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"id\": \"<uuid>\"\n}"
+						},
+						{
+							"id": "7f7bd864-6c87-4589-8ad9-d2971e94986f",
+							"name": "API token missing",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/run",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						},
+						{
+							"id": "b982f2e2-ddda-4320-b4f9-0d1067de4da6",
+							"name": "Simulation id not found",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/run",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run"
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						},
+						{
+							"id": "7c5b86ae-2381-47d9-99f8-2f7fe0fa4e17",
+							"name": "Run already exists with this id",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"description": "Added as a part of security scheme: apikey",
+										"key": "bp2022-ap1-api-key",
+										"value": "<API Key>"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/run",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"run"
+									]
+								}
+							},
+							"status": "Conflict",
+							"code": 409,
+							"_postman_previewlanguage": "text",
+							"header": [],
+							"cookie": []
+						}
+					]
+				}
+			],
+			"id": "e4fb5f16-80c7-4588-9abb-f818497b6259"
+		},
+		{
+			"name": "component",
+			"item": [
+				{
+					"name": "spawner",
+					"item": [
+						{
+							"name": "{id}",
+							"item": [
+								{
+									"name": "/component/spawner/:id",
+									"id": "1e7bba0f-875d-466c-822a-b6f2bc363c57",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "f5a51003-f61d-46ce-b8d5-08296c6b65e4",
+											"name": "Deleted spawner configuration",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "62fdb3bf-bf8a-4d76-b1c9-d28ddfdd7336",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "3cc64c54-ace9-4d63-bd08-733f5278c49e",
+											"name": "Id not found",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/spawner/:id",
+									"id": "98ad2e02-b2f0-4618-a004-d6bb061e0f47",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "4c93671d-b4ab-444a-8848-9fa66f6e0f21",
+											"name": "Successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										},
+										{
+											"id": "58bdd65c-da25-4c91-8cc8-c40aedaee41e",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "450064d2-1393-419f-8447-b2674099a4f5",
+											"name": "Id not found",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/spawner/:id",
+									"id": "b6200552-6b00-479c-b550-7f12211ffe44",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "89a4af00-0ca0-4d82-82a0-30031e87c511",
+											"name": "Updated spawner configuration",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "651798d0-9c15-4d37-a54f-3eb7c15832f0",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "3117c52d-9821-443d-a2dc-d6f1cbfe469a",
+											"name": "Id not found",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "12c0aa94-6822-4063-a74a-91f74f3effbe",
+											"name": "It's forbidden to edit an already ran simulation",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/spawner/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"spawner",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Method Not Allowed",
+											"code": 405,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								}
+							],
+							"id": "f285f2d7-38f0-4fea-8c75-424bd55dfd01"
+						},
+						{
+							"name": "/component/spawner",
+							"id": "8161dd7e-0230-4c52-8fbb-c3f8d4fba238",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/component/spawner?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"component",
+										"spawner"
+									],
+									"query": [
+										{
+											"description": "Specify id of simulation if you only want to get the spawner configuration of a single simulation",
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "3f13cc3a-8902-443c-b332-c2a7b8986e3a",
+									"name": "Successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the spawner configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+								},
+								{
+									"id": "1947dd47-813d-4a88-bd80-b794fdc3b70b",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the spawner configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "f3f68a8a-f63a-4fe7-8c9f-bb9e76d9e229",
+									"name": "Simulation not found",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the spawner configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/component/spawner",
+							"id": "d4a16662-baf9-4f95-9dbb-2a707afdcdac",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/component/spawner",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"component",
+										"spawner"
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "a72f40a3-ecfa-4988-a99d-3d7cf1b2e3b7",
+									"name": "Successfully created new spawner configuration object",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"<uuid>\"\n}"
+								},
+								{
+									"id": "7fe172b9-e692-4b8b-ad72-e653421902a5",
+									"name": "An spawner configuration exists for this simulation already",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner"
+											]
+										}
+									},
+									"status": "Bad Request",
+									"code": 400,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "afaa53bf-b739-471c-8b7b-8541d3ebf61f",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/spawner",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"spawner"
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						}
+					],
+					"id": "c81a8dbf-262a-4c0d-b8b6-63c6f95da3f5"
+				},
+				{
+					"name": "interlocking",
+					"item": [
+						{
+							"name": "{id}",
+							"item": [
+								{
+									"name": "/component/interlocking/:id",
+									"id": "6a20a77f-7bd5-4424-8249-fa454db5df82",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "06c9e7e4-5ecc-438a-9a44-964546daadc7",
+											"name": "Deleted interlocking configuration",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "1d62e893-c122-419a-a248-223c1b63b406",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "e465ce91-9ca6-42df-a679-ac3fbf1217cd",
+											"name": "Id not found",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/interlocking/:id",
+									"id": "ba0f6e56-92af-4699-a45d-a4bfef7b69cf",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "2d17f0fd-a219-4c4d-b877-105cddd8fb08",
+											"name": "Successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										},
+										{
+											"id": "6e0c2c7c-3f77-4a26-98a3-ca2814d395a0",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "74c7fea7-19fc-4627-8a1e-8fe18d3a8496",
+											"name": "Id not found",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/interlocking/:id",
+									"id": "363b9439-ad50-4aaa-bfd0-ce5672977800",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "ed945a50-cadc-4cc3-9e60-63589bb47f23",
+											"name": "Updated interlocking configuration",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "No Content",
+											"code": 204,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "2f8a36e8-b56e-4d31-a92c-9a5465733b2c",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "dcf1bd5a-419b-4bff-a306-76d0526ca565",
+											"name": "Id not found",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "15947484-f25b-4cef-8f77-edb3e828fda8",
+											"name": "It's forbidden to edit an already ran simulation",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/interlocking/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"interlocking",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "Method Not Allowed",
+											"code": 405,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								}
+							],
+							"id": "d92a389c-fba4-45e6-b756-32659725ffa3"
+						},
+						{
+							"name": "/component/interlocking",
+							"id": "7dcdc678-e363-4256-913d-c93564c87ca9",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/component/interlocking?simulationId=<uuid>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"component",
+										"interlocking"
+									],
+									"query": [
+										{
+											"description": "Specify id of simulation if you only want to get the interlocking configuration of a single simulation",
+											"key": "simulationId",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "25655f71-2b71-458c-8269-42f08ee89b1f",
+									"name": "Successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the interlocking configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+								},
+								{
+									"id": "e5133690-90bc-4a90-993a-d273eacd93ed",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the interlocking configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "788fd1a9-100d-4fcc-8867-0d102d2c27fb",
+									"name": "Simulation not found",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the interlocking configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/component/interlocking",
+							"id": "3eb26590-c567-4879-af74-5d5396dfe716",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/component/interlocking",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"component",
+										"interlocking"
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "4eff9b30-cff8-462a-adef-255ab4b82eaa",
+									"name": "Successfully created new interlocking configuration object",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"id\": \"<uuid>\"\n}"
+								},
+								{
+									"id": "ce1584eb-13ad-463e-b4d1-de5ed4fc3a36",
+									"name": "An interlocking configuration exists for this simulation already",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking"
+											]
+										}
+									},
+									"status": "Bad Request",
+									"code": 400,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "635f82de-4215-4dd5-8a1b-169af7118b9b",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/interlocking",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"interlocking"
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						}
+					],
+					"id": "08e286a7-f41b-4c57-bdba-a9b5b9e7a690"
+				},
+				{
+					"name": "fault-injection",
+					"item": [
+						{
+							"name": "train-speed-fault",
+							"item": [
+								{
+									"name": "{id}",
+									"item": [
+										{
+											"name": "/component/fault-injection/train-speed-fault/:id",
+											"id": "46fb04bd-f2fd-4c3c-a2ce-156a75d44fef",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "4a3dd79e-b013-43df-aec7-b2500333c7ca",
+													"name": "Deleted train-speed-fault configuration",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "2b00099a-af68-462e-9d16-efee5ec9cc5e",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "b7d3facc-8aca-48c3-94f4-e3b9a2acf943",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/train-speed-fault/:id",
+											"id": "ff9289cd-0158-4eb6-9dcb-7d3049961ea3",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "c407d69f-303d-4ad0-bf05-6f4bfadf2c50",
+													"name": "Successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"id": "85300783-daee-428a-91bf-386e71719f0e",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "d27ba124-bd02-4c65-bb85-844822b3c061",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/train-speed-fault/:id",
+											"id": "fb872b79-4feb-4be5-9154-0ffc7552d317",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "d5698e17-d8c6-41ba-8564-76d285033b81",
+													"name": "Updated train-speed-fault configuration",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "e8af0051-0815-4f0a-92b6-ee5dab999751",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "baac5504-52c8-4fbb-9485-3009b6b36603",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "34b7589c-c274-4a74-8210-44356cb989dc",
+													"name": "It's forbidden to edit an already ran simulation",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-speed-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Method Not Allowed",
+													"code": 405,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										}
+									],
+									"id": "1ee814f1-1d63-4ea6-b575-3d50242f0803"
+								},
+								{
+									"name": "/component/fault-injection/train-speed-fault",
+									"id": "c632ba09-7948-425d-86e6-757334155834",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"train-speed-fault"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the train-speed-fault configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "9913c7be-4901-43e3-8014-f01398d3679c",
+											"name": "Successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the train-speed-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+										},
+										{
+											"id": "8b75a3a2-28f6-4aca-8a25-d9f70411858f",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the train-speed-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "23d1714b-6416-4e09-801e-d43bd1344e87",
+											"name": "Simulation not found",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the train-speed-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/fault-injection/train-speed-fault",
+									"id": "f5313998-20b6-40b5-9ac3-d75ffc45c9a4",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"train-speed-fault"
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "52b56b2c-b8cc-4635-8ae8-b1a676a3fc6d",
+											"name": "Successfully created new train-speed-fault configuration object",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\"\n}"
+										},
+										{
+											"id": "5cc2fab1-bfbf-4a52-ad7f-f75560959a80",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-speed-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-speed-fault"
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								}
+							],
+							"id": "43900a5f-8ce9-4a2f-b6db-2046ba6fe7f0"
+						},
+						{
+							"name": "train-prio-fault",
+							"item": [
+								{
+									"name": "{id}",
+									"item": [
+										{
+											"name": "/component/fault-injection/train-prio-fault/:id",
+											"id": "b069ff42-26c9-4514-9aad-b5db58085edc",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "18c1f625-8c53-471e-b4ee-ddb36fd63c4e",
+													"name": "Deleted train-prio-fault configuration",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "8241e9cf-a523-4a21-9359-9c05b0d78269",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "6910d2b4-005b-4898-bcfc-cfb952304591",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/train-prio-fault/:id",
+											"id": "c1535424-48b6-4a2b-94d9-ebd5ab877cf3",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "c1cd6f6c-e065-4ed6-9dad-c6867614cc23",
+													"name": "Successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"id": "82d11003-9e46-43a9-b876-4f4aebb99294",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "2220ba44-dd18-4acb-90f0-57dac56316f5",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/train-prio-fault/:id",
+											"id": "c1baf174-2fb0-408a-ac50-1b632eeb14f6",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "28588aec-aa47-4ff4-85e0-d6486d37d902",
+													"name": "Updated train-prio-fault configuration",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "46fb3f19-be48-4835-94dc-27b2e5740798",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "991ef6f8-8b69-4205-9855-a1a9da2ce6aa",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "af229334-8817-4d84-9038-b09fdbf027af",
+													"name": "It's forbidden to edit an already ran simulation",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"train-prio-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Method Not Allowed",
+													"code": 405,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										}
+									],
+									"id": "371fd999-5659-4be1-9c01-1a2f30e25734"
+								},
+								{
+									"name": "/component/fault-injection/train-prio-fault",
+									"id": "c2193557-1149-42ca-9647-b81c10d18585",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"train-prio-fault"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the train-prio-fault configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "2767f1d3-ceb8-46b2-8150-cddb0781e7dc",
+											"name": "Successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the train-prio-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+										},
+										{
+											"id": "7a3b7342-7ee0-4166-b037-3640cc2cd5ec",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the train-prio-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "10989e8e-23bc-484a-a8b6-65316dbe5d5a",
+											"name": "Simulation not found",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the train-prio-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/fault-injection/train-prio-fault",
+									"id": "336c4474-c645-4ca3-a999-0c301cce97fe",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"train-prio-fault"
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "3cfec5f7-60bc-43af-afe2-e4ebad5d790b",
+											"name": "Successfully created new train-prio-fault configuration object",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\"\n}"
+										},
+										{
+											"id": "1a2a7b14-6a95-4a8f-8740-e8b61ff9fc9e",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/train-prio-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"train-prio-fault"
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								}
+							],
+							"id": "4f607716-1e8c-4559-ac9f-787f55baab65"
+						},
+						{
+							"name": "track-split-limit-fault",
+							"item": [
+								{
+									"name": "{id}",
+									"item": [
+										{
+											"name": "/component/fault-injection/track-split-limit-fault/:id",
+											"id": "9ceafe3f-06fd-405a-811f-7bb1c4a66b16",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-split-limit-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "f913d9a5-41cd-4f13-bd09-f6293d323f12",
+													"name": "Deleted track-speed-limit-fault configuration",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "19e0863d-d269-4c37-a45b-ce1cf98752b1",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "71263f59-9bd8-496d-8c4e-794a2ce9a978",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/track-split-limit-fault/:id",
+											"id": "1ee55e87-a7c1-4bbe-a298-5527bf8a0b28",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-split-limit-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "aa8f76b6-9c53-4d39-8257-a16a3909a777",
+													"name": "Successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"id": "a1a129f2-4ce4-4035-aecf-675da22d1c1f",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "23d96b2b-a679-4484-a90d-413902eed9a6",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/track-split-limit-fault/:id",
+											"id": "95807c18-f5a6-441c-875c-50f98e5f0ef1",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-split-limit-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "9a9827f7-bcd6-4f49-b09f-e6d6e902eb8f",
+													"name": "Updated track-speed-limit-fault configuration",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "0330b35c-8b52-42fc-99af-1a02eb6a04b1",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "b51d2104-7775-4fbd-bd1f-70ce8a1cc1d3",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "98c258be-8f4e-4c93-9ae4-a7830897064f",
+													"name": "It's forbidden to edit an already ran simulation",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-split-limit-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-split-limit-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Method Not Allowed",
+													"code": 405,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										}
+									],
+									"id": "294640d5-ed27-4131-82c7-df215e6caa57"
+								}
+							],
+							"id": "cec75c83-e795-435b-89ad-b3a12c3919dc"
+						},
+						{
+							"name": "track-speed-limit-fault",
+							"item": [
+								{
+									"name": "/component/fault-injection/track-speed-limit-fault",
+									"id": "c6f3d859-bee6-443f-a9d0-7cb3510131cd",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/track-speed-limit-fault?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"track-speed-limit-fault"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the track-speed-limit-fault configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "ef511398-eb1a-42be-a430-3fefc835ef95",
+											"name": "Successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-speed-limit-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-speed-limit-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the track-speed-limit-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+										},
+										{
+											"id": "942399e1-bb13-48af-8ebe-630fbabe9446",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-speed-limit-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-speed-limit-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the track-speed-limit-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "d1db612b-c4a5-485b-bf65-23d434d1d01e",
+											"name": "Simulation not found",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-speed-limit-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-speed-limit-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the track-speed-limit-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/fault-injection/track-speed-limit-fault",
+									"id": "d179b194-af75-4ff4-82a9-0d48857ca6d5",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/track-speed-limit-fault",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"track-speed-limit-fault"
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "58bb95d1-aabd-4ef7-8de5-1b11d677a670",
+											"name": "Successfully created new track-speed-limit-fault configuration object",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-speed-limit-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-speed-limit-fault"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\"\n}"
+										},
+										{
+											"id": "1f665b43-dfdd-43df-ba9c-bdf0e484973d",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-speed-limit-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-speed-limit-fault"
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								}
+							],
+							"id": "d673517b-2983-4901-811a-fcb0aba1ac4a"
+						},
+						{
+							"name": "track-blocked-fault",
+							"item": [
+								{
+									"name": "{id}",
+									"item": [
+										{
+											"name": "/component/fault-injection/track-blocked-fault/:id",
+											"id": "7d4c3042-52c5-4e49-8899-76e5dc3f70ef",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "788dc69b-aee6-45f6-be90-ba06f751a68d",
+													"name": "Deleted track-blocked-fault configuration",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "acf7234d-11e6-4dbb-9ae5-96031dd16e85",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "c66d628c-771a-46ea-89a0-fa4a3b168988",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/track-blocked-fault/:id",
+											"id": "6fa71c78-8f9d-4e0d-9cda-efb34a5466c4",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "50d08236-9659-43bb-8713-010410df8d58",
+													"name": "Successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"id": "bca4ab18-16a9-41e9-9f22-a86b910567d7",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "27e59a5c-9544-4133-ad2e-c717deb26380",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/track-blocked-fault/:id",
+											"id": "4946e1d5-81bd-4207-bf48-76e0f0c03263",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "2d1f2a0e-0c41-493a-bad3-a957ac77a401",
+													"name": "Updated track-blocked-fault configuration",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "239c62d5-8338-4f81-997a-e05bfdfa1161",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "f1109753-3ea8-4522-9bca-40f9ca821c61",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "1fea97f3-a04b-45d4-86f2-90d339e69431",
+													"name": "It's forbidden to edit an already ran simulation",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"track-blocked-fault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Method Not Allowed",
+													"code": 405,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										}
+									],
+									"id": "0a8ca5ce-ebff-47c7-a5c8-325730ab740a"
+								},
+								{
+									"name": "/component/fault-injection/track-blocked-fault",
+									"id": "c3371dda-e8cf-480d-bef2-ea8d993de3d4",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"track-blocked-fault"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the track-blocked-fault configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "b9145b7a-5411-4481-81e3-f9b7a4c8463a",
+											"name": "Successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the track-blocked-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+										},
+										{
+											"id": "dee707a1-de1a-49f5-b350-4e7a6700f4ce",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the track-blocked-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "14f002e5-a83c-4f13-a676-333f035b0e11",
+											"name": "Simulation not found",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the track-blocked-fault configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/fault-injection/track-blocked-fault",
+									"id": "e4ac0a70-93fa-425e-9f7a-8612d5213fa8",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"track-blocked-fault"
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "da21e2fb-8ad1-4e58-a5d3-b6202e7b71dd",
+											"name": "Successfully created new track-blocked-fault configuration object",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\"\n}"
+										},
+										{
+											"id": "2165653a-3be3-4e6e-8950-92a817d038e2",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/track-blocked-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"track-blocked-fault"
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								}
+							],
+							"id": "7670bc95-8dcf-43c1-86aa-6198ec4f32b1"
+						},
+						{
+							"name": "schedule-blockedfault",
+							"item": [
+								{
+									"name": "{id}",
+									"item": [
+										{
+											"name": "/component/fault-injection/schedule-blockedfault/:id",
+											"id": "1d0dd491-89be-497f-8800-c03dfa86652e",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blockedfault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "f8d8ed7a-f464-4f03-9af4-c98aaf06b0bd",
+													"name": "Deleted schedule-blocked-fault configuration",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "263a3697-5457-4608-9c04-b43c044405b0",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "1760eaf6-9a79-48b9-ba44-bc75f4c35d49",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/schedule-blockedfault/:id",
+											"id": "aae0e295-5709-44a0-bf6a-f99ab7231c93",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blockedfault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "7fb0a724-40d3-420b-964d-f7b3647855c8",
+													"name": "Successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"id": "8adadad2-8c32-4645-b2eb-31fd10866518",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "8562ce36-54ec-4a54-83d2-759c1279d618",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										},
+										{
+											"name": "/component/fault-injection/schedule-blockedfault/:id",
+											"id": "824f25aa-e2d6-4fb5-ab91-574311c39b32",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blockedfault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "a2f535fd-4f8f-426a-af7e-72eae855b150",
+													"name": "Updated schedule-blocked-fault configuration",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "No Content",
+													"code": 204,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "a402e9c7-a2b9-4044-a78d-ce4beef81f2a",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "14bb6385-7569-4006-8d60-a11ca53133b4",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "cb76cff0-939e-45a7-bdab-82694ebfb00a",
+													"name": "It's forbidden to edit an already ran simulation",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"headerFamily": "json",
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Method Not Allowed",
+													"code": 405,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
+										}
+									],
+									"id": "62352b38-20a3-422e-8c50-edeb8d790ee7"
+								}
+							],
+							"id": "e0f79e62-d722-4bfd-9f2c-48def385c08c"
+						},
+						{
+							"name": "schedule-blocked-fault",
+							"item": [
+								{
+									"name": "/component/fault-injection/schedule-blocked-fault",
+									"id": "c1a7ad76-5648-4a57-89db-53b834ba836a",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault?simulationId=<uuid>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"schedule-blocked-fault"
+											],
+											"query": [
+												{
+													"description": "Specify id of simulation if you only want to get the schedule-blocked-faul configuration of a single simulation",
+													"key": "simulationId",
+													"value": "<uuid>"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "960a7875-e574-4f00-a114-8d57a83b3064",
+											"name": "Successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the schedule-blocked-faul configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "[\n  \"<uuid>\",\n  \"<uuid>\"\n]"
+										},
+										{
+											"id": "b5d6f3a7-dd00-49fa-a0d0-1ac95107b502",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the schedule-blocked-faul configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										},
+										{
+											"id": "21861e39-ceb2-4543-a552-122c3cc406df",
+											"name": "Simulation not found",
+											"originalRequest": {
+												"method": "GET",
+												"header": [
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault?simulationId=<uuid>",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault"
+													],
+													"query": [
+														{
+															"description": "Specify id of simulation if you only want to get the schedule-blocked-faul configuration of a single simulation",
+															"key": "simulationId",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"status": "Not Found",
+											"code": 404,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
+								{
+									"name": "/component/fault-injection/schedule-blocked-fault",
+									"id": "e24b27e0-a461-4d67-ac09-2eea3576d6fe",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"schedule-blocked-fault"
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "70686536-25ed-49f5-9b2e-06c0d8d53170",
+											"name": "Successfully created new schedule-blocked-faul configuration object",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\"\n}"
+										},
+										{
+											"id": "b0e4da3b-e936-4d46-9ba9-520b10d3676d",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault"
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								}
+							],
+							"id": "0b541121-a732-4b3c-9fae-1bb006b08f89"
+						}
+					],
+					"id": "d3d92472-30c4-4a6f-8566-bc5b870249d9"
+				}
+			],
+			"id": "1bc3b5d0-47de-4d61-8a42-e6ab955eae68"
+		}
+	],
+	"auth": {
+		"type": "apikey",
+		"apikey": [
+			{
+				"key": "key",
+				"value": "bp2022-ap1-api-key",
+				"type": "string"
+			},
+			{
+				"key": "value",
+				"value": "{{apiKey}}",
+				"type": "string"
+			},
+			{
+				"key": "in",
+				"value": "header",
+				"type": "string"
+			}
+		]
+	},
+	"variable": [
+		{
+			"id": "f197ccd0-aa80-4359-8291-710945bdf20f",
+			"key": "baseUrl",
+			"value": "/"
+		}
+	]
+}


### PR DESCRIPTION
Fixes #102 

Add autogenerated request collection from openAPI 3.0 definition.
We can use this collection to send requests to our API in the future.

## PR checklist

- [x] Acceptance criteria fulfilled
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
