### PR TITLE
feat: added commands for coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,5 +80,13 @@ build-backend = "poetry.core.masonry.api"
     help = "Call DB utilities"
     cmd = "python3 db/local/db.py"
 
+    [tool.poe.tasks.cov]
+    help = "Run coverage report"
+    cmd = "pytest --co --cov=src"
+
+    [tool.poe.tasks.cov-xml]
+    help = "Run coverage report and write to XML file"
+    cmd = "pytest --co --cov=src --cov-report xml"
+
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Fixes #247 

2 new `poe`commands:

- `poe cov` for displaying coverage in terminal
- `poe cov-xml` to store coverage report in `coverage.xml`

See [Wiki](https://github.com/BP2022-AP1/bp2022-ap1/wiki/Coveralls#local-coverage)

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [x] Breaking changes anounced
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
