### PR TITLE
Feature: Prevent serialization and deserialization of hashedToken

### DIFF
--- a/src/implementor/models.py
+++ b/src/implementor/models.py
@@ -12,7 +12,6 @@ class Token(BaseModel):
 
         permission = marsh.fields.String(required=True)
         name = marsh.fields.String(required=True)
-        hashedToken = marsh.fields.String(required=True)
 
         def _make(self, data: dict) -> "Token":
             return Token(**data)

--- a/tests/implementor/test_table_token.py
+++ b/tests/implementor/test_table_token.py
@@ -83,7 +83,9 @@ class TestTokenSuccessfulInit:
         for key in expected_dict.keys():
             assert serialized_obj[key] == expected_dict[key]
         with pytest.raises(KeyError):
-            serialized_obj["hashedToken"]  # pylint: disable=pointless-statement
+            # We don't need the value of serialized_obj["hashedToken"] because it throws an error
+            # pylint: disable-next=pointless-statement
+            serialized_obj["hashedToken"]
 
     @pytest.mark.parametrize(
         "init_dict, expected_values",

--- a/tests/implementor/test_table_token.py
+++ b/tests/implementor/test_table_token.py
@@ -69,7 +69,6 @@ class TestTokenSuccessfulInit:
                 {
                     "name": "Owner",
                     "permission": "admin",
-                    "hashedToken": "hash",
                 },
             ),
         ],
@@ -83,6 +82,8 @@ class TestTokenSuccessfulInit:
         assert isinstance(serialized_obj["id"], str)
         for key in expected_dict.keys():
             assert serialized_obj[key] == expected_dict[key]
+        with pytest.raises(KeyError):
+            serialized_obj["hashedToken"]  # pylint: disable=pointless-statement
 
     @pytest.mark.parametrize(
         "init_dict, expected_values",
@@ -91,7 +92,6 @@ class TestTokenSuccessfulInit:
                 {
                     "name": "Owner",
                     "permission": "admin",
-                    "hashedToken": "hash",
                 },
                 {
                     "name": "Owner",
@@ -107,6 +107,18 @@ class TestTokenSuccessfulInit:
             init_dict,
         )
         assert isinstance(obj, Token)
+        obj.hashedToken = "hash"
         assert isinstance(obj.id, UUID)
         for key in expected_values.keys():
             assert getattr(obj, key) == expected_values[key]
+
+    def test_deserialization_with_hashed_token(self):
+        """Test that an object of a class cannot be deserialized."""
+        with pytest.raises(marsh.exceptions.ValidationError):
+            Token.Schema().load(
+                {
+                    "name": "Owner",
+                    "permission": "admin",
+                    "hashedToken": "hash",
+                },
+            )


### PR DESCRIPTION
Fixes #266 

 Prevent serialization and deserialization of hashedToken. 

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
