### PR TITLE
Fix: Typo "schedule-blockedfault" to "schedule-blocked-fault"

### DIFF
--- a/postman/collections/rest-api-autogenerate.json
+++ b/postman/collections/rest-api-autogenerate.json
@@ -7406,13 +7406,13 @@
 							"id": "7670bc95-8dcf-43c1-86aa-6198ec4f32b1"
 						},
 						{
-							"name": "schedule-blockedfault",
+							"name": "schedule-blocked-fault",
 							"item": [
 								{
 									"name": "{id}",
 									"item": [
 										{
-											"name": "/component/fault-injection/schedule-blockedfault/:id",
+											"name": "/component/fault-injection/schedule-blocked-fault/:id",
 											"id": "1d0dd491-89be-497f-8800-c03dfa86652e",
 											"protocolProfileBehavior": {
 												"disableBodyPruning": true
@@ -7421,14 +7421,14 @@
 												"method": "DELETE",
 												"header": [],
 												"url": {
-													"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 													"host": [
 														"{{baseUrl}}"
 													],
 													"path": [
 														"component",
 														"fault-injection",
-														"schedule-blockedfault",
+														"schedule-blocked-fault",
 														":id"
 													],
 													"variable": [
@@ -7552,156 +7552,6 @@
 										},
 										{
 											"name": "/component/fault-injection/schedule-blockedfault/:id",
-											"id": "aae0e295-5709-44a0-bf6a-f99ab7231c93",
-											"protocolProfileBehavior": {
-												"disableBodyPruning": true
-											},
-											"request": {
-												"method": "GET",
-												"header": [
-													{
-														"key": "Accept",
-														"value": "application/json"
-													}
-												],
-												"url": {
-													"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
-													"host": [
-														"{{baseUrl}}"
-													],
-													"path": [
-														"component",
-														"fault-injection",
-														"schedule-blockedfault",
-														":id"
-													],
-													"variable": [
-														{
-															"key": "id",
-															"value": "<uuid>"
-														}
-													]
-												}
-											},
-											"response": [
-												{
-													"id": "7fb0a724-40d3-420b-964d-f7b3647855c8",
-													"name": "Successful operation",
-													"originalRequest": {
-														"method": "GET",
-														"header": [
-															{
-																"description": "Added as a part of security scheme: apikey",
-																"key": "bp2022-ap1-api-key",
-																"value": "<API Key>"
-															}
-														],
-														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"component",
-																"fault-injection",
-																"schedule-blockedfault",
-																":id"
-															],
-															"variable": [
-																{
-																	"key": "id"
-																}
-															]
-														}
-													},
-													"status": "OK",
-													"code": 200,
-													"_postman_previewlanguage": "json",
-													"header": [
-														{
-															"key": "Content-Type",
-															"value": "application/json"
-														}
-													],
-													"cookie": [],
-													"body": "{}"
-												},
-												{
-													"id": "8adadad2-8c32-4645-b2eb-31fd10866518",
-													"name": "API token missing",
-													"originalRequest": {
-														"method": "GET",
-														"header": [
-															{
-																"description": "Added as a part of security scheme: apikey",
-																"key": "bp2022-ap1-api-key",
-																"value": "<API Key>"
-															}
-														],
-														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"component",
-																"fault-injection",
-																"schedule-blockedfault",
-																":id"
-															],
-															"variable": [
-																{
-																	"key": "id"
-																}
-															]
-														}
-													},
-													"status": "Unauthorized",
-													"code": 401,
-													"_postman_previewlanguage": "text",
-													"header": [],
-													"cookie": []
-												},
-												{
-													"id": "8562ce36-54ec-4a54-83d2-759c1279d618",
-													"name": "Id not found",
-													"originalRequest": {
-														"method": "GET",
-														"header": [
-															{
-																"description": "Added as a part of security scheme: apikey",
-																"key": "bp2022-ap1-api-key",
-																"value": "<API Key>"
-															}
-														],
-														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
-															"host": [
-																"{{baseUrl}}"
-															],
-															"path": [
-																"component",
-																"fault-injection",
-																"schedule-blockedfault",
-																":id"
-															],
-															"variable": [
-																{
-																	"key": "id"
-																}
-															]
-														}
-													},
-													"status": "Not Found",
-													"code": 404,
-													"_postman_previewlanguage": "text",
-													"header": [],
-													"cookie": []
-												}
-											]
-										},
-										{
-											"name": "/component/fault-injection/schedule-blockedfault/:id",
 											"id": "824f25aa-e2d6-4fb5-ab91-574311c39b32",
 											"protocolProfileBehavior": {
 												"disableBodyPruning": true
@@ -7725,14 +7575,11 @@
 													}
 												},
 												"url": {
-													"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
-													"host": [
-														"{{baseUrl}}"
-													],
+													"raw": "/component/fault-injection/schedule-blocked-fault/:id",
 													"path": [
 														"component",
 														"fault-injection",
-														"schedule-blockedfault",
+														"schedule-blocked-fault",
 														":id"
 													],
 													"variable": [
@@ -7941,16 +7788,297 @@
 													"cookie": []
 												}
 											]
+										},
+										{
+											"name": "/component/fault-injection/schedule-blocked-fault/:id",
+											"id": "aae0e295-5709-44a0-bf6a-f99ab7231c93",
+											"protocolProfileBehavior": {
+												"disableBodyPruning": true
+											},
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault",
+														":id"
+													],
+													"variable": [
+														{
+															"key": "id",
+															"value": "<uuid>"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"id": "7fb0a724-40d3-420b-964d-f7b3647855c8",
+													"name": "Successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												},
+												{
+													"id": "8adadad2-8c32-4645-b2eb-31fd10866518",
+													"name": "API token missing",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Unauthorized",
+													"code": 401,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												},
+												{
+													"id": "8562ce36-54ec-4a54-83d2-759c1279d618",
+													"name": "Id not found",
+													"originalRequest": {
+														"method": "GET",
+														"header": [
+															{
+																"description": "Added as a part of security scheme: apikey",
+																"key": "bp2022-ap1-api-key",
+																"value": "<API Key>"
+															}
+														],
+														"url": {
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"host": [
+																"{{baseUrl}}"
+															],
+															"path": [
+																"component",
+																"fault-injection",
+																"schedule-blockedfault",
+																":id"
+															],
+															"variable": [
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Not Found",
+													"code": 404,
+													"_postman_previewlanguage": "text",
+													"header": [],
+													"cookie": []
+												}
+											]
 										}
 									],
-									"id": "62352b38-20a3-422e-8c50-edeb8d790ee7"
-								}
-							],
-							"id": "e0f79e62-d722-4bfd-9f2c-48def385c08c"
-						},
-						{
-							"name": "schedule-blocked-fault",
-							"item": [
+									"id": "aab43486-ab42-4d47-b984-8643edd86ba0"
+								},
+								{
+									"name": "/component/fault-injection/schedule-blocked-fault",
+									"id": "e24b27e0-a461-4d67-ac09-2eea3576d6fe",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"key": "Accept",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"component",
+												"fault-injection",
+												"schedule-blocked-fault"
+											]
+										}
+									},
+									"response": [
+										{
+											"id": "70686536-25ed-49f5-9b2e-06c0d8d53170",
+											"name": "Successfully created new schedule-blocked-faul configuration object",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n  \"id\": \"<uuid>\"\n}"
+										},
+										{
+											"id": "b0e4da3b-e936-4d46-9ba9-520b10d3676d",
+											"name": "API token missing",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"description": "Added as a part of security scheme: apikey",
+														"key": "bp2022-ap1-api-key",
+														"value": "<API Key>"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}",
+													"options": {
+														"raw": {
+															"headerFamily": "json",
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"component",
+														"fault-injection",
+														"schedule-blocked-fault"
+													]
+												}
+											},
+											"status": "Unauthorized",
+											"code": 401,
+											"_postman_previewlanguage": "text",
+											"header": [],
+											"cookie": []
+										}
+									]
+								},
 								{
 									"name": "/component/fault-injection/schedule-blocked-fault",
 									"id": "c1a7ad76-5648-4a57-89db-53b834ba836a",
@@ -8098,143 +8226,6 @@
 											},
 											"status": "Not Found",
 											"code": 404,
-											"_postman_previewlanguage": "text",
-											"header": [],
-											"cookie": []
-										}
-									]
-								},
-								{
-									"name": "/component/fault-injection/schedule-blocked-fault",
-									"id": "e24b27e0-a461-4d67-ac09-2eea3576d6fe",
-									"protocolProfileBehavior": {
-										"disableBodyPruning": true
-									},
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Accept",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{}",
-											"options": {
-												"raw": {
-													"headerFamily": "json",
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
-											"host": [
-												"{{baseUrl}}"
-											],
-											"path": [
-												"component",
-												"fault-injection",
-												"schedule-blocked-fault"
-											]
-										}
-									},
-									"response": [
-										{
-											"id": "70686536-25ed-49f5-9b2e-06c0d8d53170",
-											"name": "Successfully created new schedule-blocked-faul configuration object",
-											"originalRequest": {
-												"method": "POST",
-												"header": [
-													{
-														"key": "Content-Type",
-														"value": "application/json"
-													},
-													{
-														"description": "Added as a part of security scheme: apikey",
-														"key": "bp2022-ap1-api-key",
-														"value": "<API Key>"
-													}
-												],
-												"body": {
-													"mode": "raw",
-													"raw": "{}",
-													"options": {
-														"raw": {
-															"headerFamily": "json",
-															"language": "json"
-														}
-													}
-												},
-												"url": {
-													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
-													"host": [
-														"{{baseUrl}}"
-													],
-													"path": [
-														"component",
-														"fault-injection",
-														"schedule-blocked-fault"
-													]
-												}
-											},
-											"status": "Created",
-											"code": 201,
-											"_postman_previewlanguage": "json",
-											"header": [
-												{
-													"key": "Content-Type",
-													"value": "application/json"
-												}
-											],
-											"cookie": [],
-											"body": "{\n  \"id\": \"<uuid>\"\n}"
-										},
-										{
-											"id": "b0e4da3b-e936-4d46-9ba9-520b10d3676d",
-											"name": "API token missing",
-											"originalRequest": {
-												"method": "POST",
-												"header": [
-													{
-														"key": "Content-Type",
-														"value": "application/json"
-													},
-													{
-														"description": "Added as a part of security scheme: apikey",
-														"key": "bp2022-ap1-api-key",
-														"value": "<API Key>"
-													}
-												],
-												"body": {
-													"mode": "raw",
-													"raw": "{}",
-													"options": {
-														"raw": {
-															"headerFamily": "json",
-															"language": "json"
-														}
-													}
-												},
-												"url": {
-													"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault",
-													"host": [
-														"{{baseUrl}}"
-													],
-													"path": [
-														"component",
-														"fault-injection",
-														"schedule-blocked-fault"
-													]
-												}
-											},
-											"status": "Unauthorized",
-											"code": 401,
 											"_postman_previewlanguage": "text",
 											"header": [],
 											"cookie": []

--- a/postman/collections/rest-api-autogenerate.json
+++ b/postman/collections/rest-api-autogenerate.json
@@ -7551,7 +7551,7 @@
 											]
 										},
 										{
-											"name": "/component/fault-injection/schedule-blockedfault/:id",
+											"name": "/component/fault-injection/schedule-blocked-fault/:id",
 											"id": "824f25aa-e2d6-4fb5-ab91-574311c39b32",
 											"protocolProfileBehavior": {
 												"disableBodyPruning": true

--- a/postman/collections/rest-api-autogenerate.json
+++ b/postman/collections/rest-api-autogenerate.json
@@ -7453,14 +7453,14 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7489,14 +7489,14 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7525,14 +7525,14 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7618,14 +7618,14 @@
 															}
 														},
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7668,14 +7668,14 @@
 															}
 														},
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7718,14 +7718,14 @@
 															}
 														},
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7764,14 +7764,14 @@
 															}
 														},
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7836,14 +7836,14 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7878,14 +7878,14 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [
@@ -7914,14 +7914,14 @@
 															}
 														],
 														"url": {
-															"raw": "{{baseUrl}}/component/fault-injection/schedule-blockedfault/:id",
+															"raw": "{{baseUrl}}/component/fault-injection/schedule-blocked-fault/:id",
 															"host": [
 																"{{baseUrl}}"
 															],
 															"path": [
 																"component",
 																"fault-injection",
-																"schedule-blockedfault",
+																"schedule-blocked-fault",
 																":id"
 															],
 															"variable": [

--- a/postman/schemas/index.yaml
+++ b/postman/schemas/index.yaml
@@ -185,7 +185,7 @@ paths:
         Insert a new schedule-blocked-faul component. Returns the id of the
         configuration object.
 
-  /component/fault-injection/schedule-blockedfault/{id}:
+  /component/fault-injection/schedule-blocked-fault/{id}:
     delete:
       operationId: delete_schedule_blocked_fault_configuration
       parameters:

--- a/src/api/component.py
+++ b/src/api/component.py
@@ -27,7 +27,7 @@ def create_schedule_blocked_fault_configuration():
 
 
 @bp.route(
-    "/component/fault-injection/schedule-blockedfault/<identifier>", methods=["get"]
+    "/component/fault-injection/schedule-blocked-fault/<identifier>", methods=["get"]
 )
 def get_schedule_blocked_fault_configuration(identifier):
     """Get a schedule blocked fault configuration"""
@@ -38,7 +38,7 @@ def get_schedule_blocked_fault_configuration(identifier):
 
 
 @bp.route(
-    "/component/fault-injection/schedule-blockedfault/<identifier>", methods=["put"]
+    "/component/fault-injection/schedule-blocked-fault/<identifier>", methods=["put"]
 )
 def update_schedule_blocked_fault_configuration(identifier):
     """Update a schedule blocked fault configuration"""
@@ -53,7 +53,7 @@ def update_schedule_blocked_fault_configuration(identifier):
 
 
 @bp.route(
-    "/component/fault-injection/schedule-blockedfault/<identifier>", methods=["delete"]
+    "/component/fault-injection/schedule-blocked-fault/<identifier>", methods=["delete"]
 )
 def delete_schedule_blocked_fault_configuration(identifier):
     """Delete a schedule blocked fault configuration"""

--- a/tests/api/test_api_schedule_blocked_fault.py
+++ b/tests/api/test_api_schedule_blocked_fault.py
@@ -17,20 +17,20 @@ class TestApiScheduleBlockedFault:
     def test_get_single(self, client):
         object_id = uuid.uuid4()
         response = client.get(
-            f"/component/fault-injection/schedule-blockedfault/{object_id}"
+            f"/component/fault-injection/schedule-blocked-fault/{object_id}"
         )
         assert response.status_code == 501
 
     def test_update(self, client):
         object_id = uuid.uuid4()
         response = client.put(
-            f"/component/fault-injection/schedule-blockedfault/{object_id}"
+            f"/component/fault-injection/schedule-blocked-fault/{object_id}"
         )
         assert response.status_code == 501
 
     def test_delete(self, client):
         object_id = uuid.uuid4()
         response = client.delete(
-            f"/component/fault-injection/schedule-blockedfault/{object_id}"
+            f"/component/fault-injection/schedule-blocked-fault/{object_id}"
         )
         assert response.status_code == 501


### PR DESCRIPTION
Fixes #<n>

Typo "schedule-blockedfault" to "schedule-blocked-fault" in openapi3 definition, collections and code

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
