### PR TITLE
Fix/260 train creation

### DIFF
--- a/src/wrapper/simulation_objects.py
+++ b/src/wrapper/simulation_objects.py
@@ -284,6 +284,8 @@ class Platform(SimulationObject):
 class Train(SimulationObject):
     """A train driving around in the simulation."""
 
+    # pylint: disable=too-many-instance-attributes
+
     class TrainType(SimulationObject):
         """Metadata about a specific train"""
 

--- a/src/wrapper/simulation_objects.py
+++ b/src/wrapper/simulation_objects.py
@@ -443,6 +443,7 @@ class Train(SimulationObject):
         identifier: str = None,
         timetable: List[str] = None,
         train_type: str = None,
+        updater: "SimulationObjectUpdatingComponent" = None,
         from_simulator: bool = False,
     ):
         """Creates a new train from the given parameters.
@@ -457,6 +458,7 @@ class Train(SimulationObject):
         You probably don't need to touch this.
         """
         SimulationObject.__init__(self, identifier=identifier)
+        self.updater = updater
 
         self.train_type = Train.TrainType.from_sumo_type(train_type, identifier)
         self._convert_timetable(timetable)

--- a/tests/wrapper/test_simulation_objects.py
+++ b/tests/wrapper/test_simulation_objects.py
@@ -1,5 +1,6 @@
 import pytest
 from traci import constants, edge, trafficlight, vehicle
+from uuid import uuid4
 
 from src.wrapper.simulation_object_updating_component import (
     SimulationObjectUpdatingComponent,
@@ -36,7 +37,8 @@ def speed_update(monkeypatch):
 
 
 @pytest.fixture
-def train():
+def train(train_add):
+    # pylint: disable=unused-argument
     created_train = Train(
         identifier="fake-sim-train",
         train_type="fancy-ice",
@@ -84,9 +86,9 @@ def max_speed(monkeypatch):
 @pytest.fixture
 def train_add(monkeypatch):
     def add_train(identifier, route, train_type):
-        assert identifier == "fancy-rb-001"
-        assert route == "not-implemented"
-        assert train_type == "fancy-rb"
+        assert identifier is not None
+        assert route is not None
+        assert train_type is not None
 
     monkeypatch.setattr(vehicle, "add", add_train)
 
@@ -106,9 +108,17 @@ def platform() -> Platform:
 
 
 @pytest.fixture
-def souc(traffic_update):
+def souc(traffic_update) -> SimulationObjectUpdatingComponent:
     # pylint: disable=unused-argument
     return SimulationObjectUpdatingComponent()
+
+
+@pytest.fixture
+def configured_souc(traffic_update) -> SimulationObjectUpdatingComponent:
+    # pylint: disable=unused-argument
+    return SimulationObjectUpdatingComponent(
+        sumo_configuration="sumo-config/example.scenario.sumocfg"
+    )
 
 
 class TestSignal:
@@ -241,6 +251,18 @@ class TestTrain:
 
     def test_subscription(self, train):
         assert train.add_subscriptions() > 0
+
+    def test_spawn_loaded_net(self, configured_souc, train_add):
+        # pylint: disable=unused-argument
+        p1_id = "station-1"
+        p2_id = "station-2"
+
+        Train(
+            identifier=f"{uuid4()}_42",
+            timetable=[p1_id, p2_id],
+            train_type="cargo",
+            updater=configured_souc,
+        )
 
 
 class TestSwitch:

--- a/tests/wrapper/test_simulation_objects.py
+++ b/tests/wrapper/test_simulation_objects.py
@@ -1,6 +1,7 @@
+from uuid import uuid4
+
 import pytest
 from traci import constants, edge, trafficlight, vehicle
-from uuid import uuid4
 
 from src.wrapper.simulation_object_updating_component import (
     SimulationObjectUpdatingComponent,


### PR DESCRIPTION
Fixes #260

The spawning of a train is more complicated than described in the issue, see the added test

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [x] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
