### PR TITLE
Feature: Add route skeleton to update simulation configurations

### DIFF
--- a/postman/collections/rest-api-autogenerate.json
+++ b/postman/collections/rest-api-autogenerate.json
@@ -325,6 +325,242 @@
 						},
 						{
 							"name": "/simulation/:id",
+							"id": "b3095852-9cf1-45f9-851e-a2d60b27412c",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/simulation/:id",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"simulation",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "<uuid>"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"id": "a9e33649-a4e4-499c-b72c-96cec8b11b6c",
+									"name": "Updated simulation configuration",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "833d3386-79e5-413d-a465-1e9eb421141e",
+									"name": "API token missing",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "c32b2502-3fd0-46b9-973f-141dd4061887",
+									"name": "Id not found",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Not Found",
+									"code": 404,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": []
+								},
+								{
+									"id": "56630523-937f-4c21-866c-726b05977bee",
+									"name": "It's forbidden to edit an already ran simulation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											},
+											{
+												"description": "Added as a part of security scheme: apikey",
+												"key": "bp2022-ap1-api-key",
+												"value": "<API Key>"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{}",
+											"options": {
+												"raw": {
+													"headerFamily": "json",
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/simulation/:id",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"simulation",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id"
+												}
+											]
+										}
+									},
+									"status": "Method Not Allowed",
+									"code": 405,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": []
+								}
+							]
+						},
+						{
+							"name": "/simulation/:id",
 							"id": "a602de61-8874-4110-9d87-0c32c85f3fc7",
 							"protocolProfileBehavior": {
 								"disableBodyPruning": true

--- a/postman/schemas/index.yaml
+++ b/postman/schemas/index.yaml
@@ -1049,6 +1049,31 @@ paths:
       summary:
         "Get all information about a simulation, including the ids of connected\
         \ components and runs."
+    
+    put:
+      operationId: update_simulation_configuration
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: uuid
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimulationConfigurationUpdate"
+      responses:
+        "200":
+          description: Updated simulation configuration
+        "401":
+          description: API token missing
+        "404":
+          description: Id not found
+        "405":
+          description: It's forbidden to edit an already ran simulation
+      summary: Edit the component configurations connected to the simulation configuration.
 
   /token:
     post:
@@ -1079,6 +1104,8 @@ components:
     Token:
       type: object
     SimulationConfiguration:
+      type: object
+    SimulationConfigurationUpdate:
       type: object
     InterlockingConfiguration:
       type: object

--- a/src/api/simulation.py
+++ b/src/api/simulation.py
@@ -32,6 +32,19 @@ def get_simulation_configuration(identifier):
     return impl.simulation.get_simulation_configuration(options)
 
 
+@bp.route("/simulation/<identifier>", methods=["put"])
+def update_simulation_configuration(identifier):
+    """Update a simulation configuration"""
+    options = {}
+    options["identifier"] = identifier
+
+    schema = model.SimulationConfiguration()
+
+    body = parser.parse(schema, request, location="json")
+
+    return impl.simulation.update_simulation_configuration(options, body)
+
+
 @bp.route("/simulation/<identifier>", methods=["delete"])
 def delete_simulation_configuration(identifier):
     """Delete a simulation configuration"""

--- a/src/implementor/simulation.py
+++ b/src/implementor/simulation.py
@@ -47,6 +47,19 @@ def get_simulation_configuration(options):
     return json.dumps("<map>"), 501  # 200
 
 
+def update_simulation_configuration(options, body):
+    """
+    :param options: A dictionary containing all the paramters for the Operations
+        options["id"]
+    :param body: The parsed body of the request
+    """
+
+    # Implement your business logic here
+    # All the parameters are present in the options argument
+
+    return "", 501  # 200
+
+
 def delete_simulation_configuration(options):
     """
     :param options: A dictionary containing all the paramters for the Operations

--- a/tests/api/test_api_simulation.py
+++ b/tests/api/test_api_simulation.py
@@ -19,6 +19,11 @@ class TestApiSimulation:
         response = client.get(f"/simulation/{object_id}")
         assert response.status_code == 501
 
+    def test_update(self, client):
+        object_id = uuid.uuid4()
+        response = client.put(f"/simulation/{object_id}")
+        assert response.status_code == 501
+
     def test_delete(self, client):
         object_id = uuid.uuid4()
         response = client.delete(f"/simulation/{object_id}")


### PR DESCRIPTION
Fixes #357 

This PR adds the route to update a simulation configuration back.
A user can control the connected components with this route in the future.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
