### PR TITLE
Refactor: Use unifromly naming for operationid for fetching all ids

### DIFF
--- a/postman/schemas/index.yaml
+++ b/postman/schemas/index.yaml
@@ -106,7 +106,7 @@ paths:
 
   /component/fault-injection/schedule-blocked-fault:
     get:
-      operationId: get_schedule_blocked_fault_configuration_ids
+      operationId: get_all_schedule_blocked_fault_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the schedule-blocked-faul
@@ -202,7 +202,7 @@ paths:
 
   /component/fault-injection/track-blocked-fault:
     get:
-      operationId: get_track_blocked_fault_configuration_ids
+      operationId: get_all_track_blocked_fault_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the track-blocked-fault
@@ -298,7 +298,7 @@ paths:
 
   /component/fault-injection/track-speed-limit-fault:
     get:
-      operationId: get_track_speed_limit_fault_configuration_ids
+      operationId: get_all_track_speed_limit_fault_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the track-speed-limit-fault
@@ -394,7 +394,7 @@ paths:
 
   /component/fault-injection/train-prio-fault:
     get:
-      operationId: get_train_prio_fault_configuration_ids
+      operationId: get_all_train_prio_fault_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the train-prio-fault
@@ -488,7 +488,7 @@ paths:
 
   /component/fault-injection/train-speed-fault:
     get:
-      operationId: get_train_speed_fault_configuration_ids
+      operationId: get_all_train_speed_fault_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the train-speed-fault
@@ -582,7 +582,7 @@ paths:
 
   /component/fault-injection/platform-blocked-fault:
     get:
-      operationId: get_train_platform_blocked_configuration_ids
+      operationId: get_all_train_platform_blocked_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the platform-blocked-fault
@@ -676,7 +676,7 @@ paths:
 
   /component/interlocking:
     get:
-      operationId: get_interlocking_configuration_ids
+      operationId: get_all_interlocking_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the interlocking
@@ -772,7 +772,7 @@ paths:
 
   /component/spawner:
     get:
-      operationId: get_spawner_configuration_ids
+      operationId: get_all_spawner_configuration_ids
       parameters:
         - description:
             Specify id of simulation if you only want to get the spawner
@@ -868,7 +868,7 @@ paths:
 
   /run:
     get:
-      operationId: get_all_run_id
+      operationId: get_all_run_ids
       parameters:
         - in: query
           name: simulationId
@@ -965,7 +965,7 @@ paths:
 
   /simulation:
     get:
-      operationId: get_all_simulation_id
+      operationId: get_all_simulation_ids
       responses:
         "200":
           content:

--- a/src/api/component.py
+++ b/src/api/component.py
@@ -8,12 +8,12 @@ bp = Blueprint("component", __name__)
 
 
 @bp.route("/component/fault-injection/schedule-blocked-fault", methods=["get"])
-def get_schedule_blocked_fault_configuration_ids():
+def get_all_schedule_blocked_fault_configuration_ids():
     """Get all schedule blocked fault configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_schedule_blocked_fault_configuration_ids(options)
+    return impl.component.get_all_schedule_blocked_fault_configuration_ids(options)
 
 
 @bp.route("/component/fault-injection/schedule-blocked-fault", methods=["post"])
@@ -49,12 +49,12 @@ def delete_schedule_blocked_fault_configuration(identifier):
 
 
 @bp.route("/component/fault-injection/track-blocked-fault", methods=["get"])
-def get_track_blocked_fault_configuration_ids():
+def get_all_track_blocked_fault_configuration_ids():
     """Get all track blocked fault configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_track_blocked_fault_configuration_ids(options)
+    return impl.component.get_all_track_blocked_fault_configuration_ids(options)
 
 
 @bp.route("/component/fault-injection/track-blocked-fault", methods=["post"])
@@ -90,12 +90,12 @@ def delete_track_blocked_fault_configuration(identifier):
 
 
 @bp.route("/component/fault-injection/track-speed-limit-fault", methods=["get"])
-def get_track_speed_limit_fault_configuration_ids():
+def get_all_track_speed_limit_fault_configuration_ids():
     """Get all track speed limit fault configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_track_speed_limit_fault_configuration_ids(options)
+    return impl.component.get_all_track_speed_limit_fault_configuration_ids(options)
 
 
 @bp.route("/component/fault-injection/track-speed-limit-fault", methods=["post"])
@@ -132,12 +132,12 @@ def delete_track_speed_limit_fault_configuration(identifier):
 
 
 @bp.route("/component/fault-injection/train-prio-fault", methods=["get"])
-def get_train_prio_fault_configuration_ids():
+def get_all_train_prio_fault_configuration_ids():
     """Get all train prio fault configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_train_prio_fault_configuration_ids(options)
+    return impl.component.get_all_train_prio_fault_configuration_ids(options)
 
 
 @bp.route("/component/fault-injection/train-prio-fault", methods=["post"])
@@ -171,12 +171,12 @@ def delete_train_prio_fault_configuration(identifier):
 
 
 @bp.route("/component/fault-injection/train-speed-fault", methods=["get"])
-def get_train_speed_fault_configuration_ids():
+def get_all_train_speed_fault_configuration_ids():
     """Get all train speed fault configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_train_speed_fault_configuration_ids(options)
+    return impl.component.get_all_train_speed_fault_configuration_ids(options)
 
 
 @bp.route("/component/fault-injection/train-speed-fault", methods=["post"])
@@ -210,12 +210,12 @@ def delete_train_speed_fault_configuration(identifier):
 
 
 @bp.route("/component/fault-injection/platform-blocked-fault", methods=["get"])
-def get_platform_blocked_fault_configuration_ids():
+def get_all_platform_blocked_fault_configuration_ids():
     """Get all platform blocked fault configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_platform_blocked_fault_configuration_ids(options)
+    return impl.component.get_all_platform_blocked_fault_configuration_ids(options)
 
 
 @bp.route("/component/fault-injection/platform-blocked-fault", methods=["post"])
@@ -251,12 +251,12 @@ def delete_platform_blocked_fault_configuration(identifier):
 
 
 @bp.route("/component/interlocking", methods=["get"])
-def get_interlocking_configuration_ids():
+def get_all_interlocking_configuration_ids():
     """Get all interlocking configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_interlocking_configuration_ids(options)
+    return impl.component.get_all_interlocking_configuration_ids(options)
 
 
 @bp.route("/component/interlocking", methods=["post"])
@@ -288,12 +288,12 @@ def delete_interlocking_configuration(identifier):
 
 
 @bp.route("/component/spawner", methods=["get"])
-def get_spawner_configuration_ids():
+def get_all_spawner_configuration_ids():
     """Get all spawner configuration ids"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.component.get_spawner_configuration_ids(options)
+    return impl.component.get_all_spawner_configuration_ids(options)
 
 
 @bp.route("/component/spawner", methods=["post"])

--- a/src/api/run.py
+++ b/src/api/run.py
@@ -8,12 +8,12 @@ bp = Blueprint("run", __name__)
 
 
 @bp.route("/run", methods=["get"])
-def get_all_run_id():
+def get_all_run_ids():
     """Get all run id"""
     options = {}
     options["simulationId"] = request.args.get("simulationId")
 
-    return impl.run.get_all_run_id(options)
+    return impl.run.get_all_run_ids(options)
 
 
 @bp.route("/run", methods=["post"])

--- a/src/api/simulation.py
+++ b/src/api/simulation.py
@@ -8,9 +8,9 @@ bp = Blueprint("simulation", __name__)
 
 
 @bp.route("/simulation", methods=["get"])
-def get_all_simulation_id():
+def get_all_simulation_ids():
     """Get all simulation id"""
-    return impl.simulation.get_all_simulation_id()
+    return impl.simulation.get_all_simulation_ids()
 
 
 @bp.route("/simulation", methods=["post"])

--- a/src/implementor/component.py
+++ b/src/implementor/component.py
@@ -4,7 +4,7 @@
 import json
 
 
-def get_schedule_blocked_fault_configuration_ids(options):
+def get_all_schedule_blocked_fault_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation
@@ -63,7 +63,7 @@ def delete_schedule_blocked_fault_configuration(options):
     return "", 501  # 204
 
 
-def get_track_blocked_fault_configuration_ids(options):
+def get_all_track_blocked_fault_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation
@@ -122,7 +122,7 @@ def delete_track_blocked_fault_configuration(options):
     return "", 501  # 204
 
 
-def get_track_speed_limit_fault_configuration_ids(options):
+def get_all_track_speed_limit_fault_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation
@@ -181,7 +181,7 @@ def delete_track_speed_limit_fault_configuration(options):
     return "", 501  # 204
 
 
-def get_train_prio_fault_configuration_ids(options):
+def get_all_train_prio_fault_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation
@@ -240,7 +240,7 @@ def delete_train_prio_fault_configuration(options):
     return "", 501  # 204
 
 
-def get_train_speed_fault_configuration_ids(options):
+def get_all_train_speed_fault_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation
@@ -299,7 +299,7 @@ def delete_train_speed_fault_configuration(options):
     return "", 501  # 204
 
 
-def get_platform_blocked_fault_configuration_ids(options):
+def get_all_platform_blocked_fault_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation
@@ -358,7 +358,7 @@ def delete_platform_blocked_fault_configuration(options):
     return "", 501  # 204
 
 
-def get_interlocking_configuration_ids(options):
+def get_all_interlocking_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation
@@ -417,7 +417,7 @@ def delete_interlocking_configuration(options):
     return "", 501  # 204
 
 
-def get_spawner_configuration_ids(options):
+def get_all_spawner_configuration_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]: Specify id of simulation

--- a/src/implementor/run.py
+++ b/src/implementor/run.py
@@ -4,7 +4,7 @@
 import json
 
 
-def get_all_run_id(options):
+def get_all_run_ids(options):
     """
     :param options: A dictionary containing all the paramters for the Operations
         options["simulationId"]

--- a/src/implementor/simulation.py
+++ b/src/implementor/simulation.py
@@ -4,7 +4,7 @@
 import json
 
 
-def get_all_simulation_id():
+def get_all_simulation_ids():
     """
     Get all simulation ids
     """


### PR DESCRIPTION
Fixes #<n>

Use `get_all_..._ids` as a template for the operation id for fetching all ids of components, simulations or runs.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
