### PR TITLE
Recofigure test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    @abstract

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ build-backend = "poetry.core.masonry.api"
 
     [tool.poe.tasks.test-pytest]
     help = "Run test with pytest"
-    cmd = "pytest --cov=src --cov-report xml"
+    cmd = "pytest --cov=src  --cov-config=.coveragerc --cov-report xml"
 
     [tool.poe.tasks.ci]
     help = "Run formatting, linting and testing in preparation for CI"
@@ -96,11 +96,11 @@ build-backend = "poetry.core.masonry.api"
 
     [tool.poe.tasks.cov]
     help = "Run coverage report"
-    cmd = "pytest --co --cov=src"
+    cmd = "pytest --co --cov=src --cov-config=.coveragerc"
 
     [tool.poe.tasks.cov-xml]
     help = "Run coverage report and write to XML file"
-    cmd = "pytest --co --cov=src --cov-report xml"
+    cmd = "pytest --co --cov=src  --cov-config=.coveragerc --cov-report xml"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Fixes #363

pytest now ignores abstract methods when calculating the test coverage.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
