### PR TITLE
Feature/351 delay not spawnable trains

### DIFF
--- a/src/schedule/schedule.py
+++ b/src/schedule/schedule.py
@@ -51,7 +51,7 @@ class Schedule(ABC):
         self.id = id_  # pylint: disable=invalid-name
 
     @abstractmethod
-    def _spawn(self, spawner: SpawnerProtocol, tick: int):
+    def _spawn(self, spawner: SpawnerProtocol, tick: int) -> bool:
         """Spawns a vehicle.
 
         :param spawner: The calling Spawner.

--- a/src/schedule/schedule.py
+++ b/src/schedule/schedule.py
@@ -20,7 +20,7 @@ class Schedule(ABC):
 
     id: str
     _blocked: bool
-    _delayed_spawn_ticks: list[int]
+    _ticks_to_be_spawned: list[int]
     strategy: ScheduleStrategy
 
     STRATEGY_CLASSES: dict[str, type] = {
@@ -46,7 +46,7 @@ class Schedule(ABC):
     def __init__(self, strategy: ScheduleStrategy, id_: str):
         """Constructs a Schedule."""
         self._blocked = False
-        self._delayed_spawn_ticks = []
+        self._ticks_to_be_spawned = []
         self.strategy = strategy
         self.id = id_  # pylint: disable=invalid-name
 
@@ -66,11 +66,11 @@ class Schedule(ABC):
         :param spawner: The calling spawner.
         """
         if not self._blocked and self.strategy.should_spawn(tick):
-            if not self._spawn(spawner, tick):
-                self._delayed_spawn_ticks.insert(0, tick)
-        elif len(self._delayed_spawn_ticks) > 0:
-            if self._spawn(spawner, self._delayed_spawn_ticks[0]):
-                self._delayed_spawn_ticks.pop(0)
+            self._ticks_to_be_spawned.append(tick)
+
+        if len(self._ticks_to_be_spawned) > 0:
+            if self._spawn(spawner, self._ticks_to_be_spawned[-1]):
+                self._ticks_to_be_spawned.pop()
 
     def block(self):
         """Blocks the schedule.

--- a/src/schedule/schedule.py
+++ b/src/schedule/schedule.py
@@ -11,6 +11,7 @@ from src.wrapper.train_spawner import TrainSpawner
 
 class SpawnerProtocol(Protocol):
     """Protocol for the Spawner"""
+
     train_spawner: TrainSpawner
 
 

--- a/src/schedule/schedule.py
+++ b/src/schedule/schedule.py
@@ -10,6 +10,7 @@ from src.wrapper.train_spawner import TrainSpawner
 
 
 class SpawnerProtocol(Protocol):
+    """Protocol for the Spawner"""
     train_spawner: TrainSpawner
 
 

--- a/src/schedule/train_schedule.py
+++ b/src/schedule/train_schedule.py
@@ -1,7 +1,6 @@
-from src.schedule.schedule import Schedule
+from src.schedule.schedule import Schedule, SpawnerProtocol
 from src.schedule.schedule_configuration import ScheduleConfiguration
 from src.schedule.schedule_strategy import ScheduleStrategy
-from src.wrapper.simulation_objects import Train
 
 
 class TrainSchedule(Schedule):
@@ -48,11 +47,13 @@ class TrainSchedule(Schedule):
         self.platform_ids = platform_ids
         super().__init__(strategy, id_)
 
-    def _spawn(self, traci_wrapper: "ITraCiWrapper", tick: int):
-        """Spawns a train.
+    def _spawn(self, spawner: SpawnerProtocol, tick: int) -> bool:
+        """Spawns a vehicle.
 
-        :param traci_wrapper: The TraCi wrapper to give the train to.
+        :param spawner: The calling Spawner.
         :param tick: The current tick
+        :return: if the spawning was successful
         """
-        train = Train(f"{self.id}_{tick}", self.platform_ids, self.train_type)
-        traci_wrapper.spawn_train(train)
+        spawner.train_spawner.spawn_train(
+            f"{self.id}_{tick}", self.platform_ids, self.train_type
+        )

--- a/src/schedule/train_schedule.py
+++ b/src/schedule/train_schedule.py
@@ -54,6 +54,6 @@ class TrainSchedule(Schedule):
         :param tick: The current tick
         :return: if the spawning was successful
         """
-        spawner.train_spawner.spawn_train(
+        return spawner.train_spawner.spawn_train(
             f"{self.id}_{tick}", self.platform_ids, self.train_type
         )

--- a/src/spawner/spawner.py
+++ b/src/spawner/spawner.py
@@ -93,7 +93,7 @@ class Spawner(Component, ISpawnerDisruptor):
         :type tick: int
         """
         for schedule in self._schedules.values():
-            schedule.maybe_spawn(tick, self.traci_wrapper)
+            schedule.maybe_spawn(tick, self)
 
     def __init__(
         self,

--- a/src/spawner/spawner.py
+++ b/src/spawner/spawner.py
@@ -9,6 +9,7 @@ from src.logger.logger import Logger
 from src.schedule.schedule import Schedule
 from src.schedule.schedule_configuration import ScheduleConfiguration
 from src.schedule.train_schedule import TrainSchedule
+from src.wrapper.train_spawner import TrainSpawner
 
 
 class SpawnerConfiguration(BaseModel):
@@ -80,8 +81,8 @@ class Spawner(Component, ISpawnerDisruptor):
     """
 
     configuration: SpawnerConfiguration
-    traci_wrapper: "ITraCiWrapper"
     _schedules: dict[str, Schedule]
+    train_spawner: TrainSpawner
 
     PRIORITY: int = 0  # This will need to be set to the correct value
 
@@ -98,13 +99,13 @@ class Spawner(Component, ISpawnerDisruptor):
         self,
         logger: Logger,
         configuration: SpawnerConfiguration,
-        traci_wrapper: "ITraCiWrapper",
+        train_spawner: TrainSpawner,
     ):
         """Initializes the spawner.
 
         :param logger: The logger.
         :param configuration: The configuration.
-        :param traci_wrapper: The TraCiWrapper.
+        :param train_spawner: The TrainSpawner.
         """
         # Method resolution order (MRO) is:
         # Spawner -> Component -> ISpawner -> ISpawnerDisruptor -> ABC -> object
@@ -113,7 +114,7 @@ class Spawner(Component, ISpawnerDisruptor):
         # pylint: disable=super-with-arguments
         super(Spawner, self).__init__(logger, self.PRIORITY)  # calls Component.__init__
         self.configuration = configuration
-        self.traci_wrapper = traci_wrapper
+        self.train_spawner = train_spawner
         self._load_schedules()
 
     SCHEDULE_SUBCLASS_MAPPINGS: dict[str, type[Schedule]] = {

--- a/tests/fault_injector/conftest.py
+++ b/tests/fault_injector/conftest.py
@@ -143,8 +143,8 @@ def spawner_configuration(schedule):
     return configuration
 
 
-class MockTraCIWrapper:
-    """Mock class for a TraCI wrapper"""
+class MockTrainSpawner:
+    """Mock class for a TrainSpawner"""
 
 
 @pytest.fixture
@@ -152,6 +152,6 @@ def spawner(spawner_configuration, logger):
     spawner = Spawner(
         logger=logger,
         configuration=spawner_configuration,
-        traci_wrapper=MockTraCIWrapper(),
+        train_spawner=MockTrainSpawner(),
     )
     return spawner

--- a/tests/spawner/conftest.py
+++ b/tests/spawner/conftest.py
@@ -924,11 +924,14 @@ def mock_train_spawner() -> object:
         def __init__(self):
             self._next_spawn_fails = False
 
-        def spawn_train(self, identifier: str, timetable: list[str], train_type: str):
+        def spawn_train(self, identifier: str, timetable: list[str], train_type: str) -> bool:
+            if self._next_spawn_fails:
+                self._next_spawn_fails = False
+                return False
             self.identifier = identifier
             self.timetable = timetable
             self.train_type = train_type
-            self._next_spawn_fails = False
+            return True
 
         def let_next_spawn_fail(self):
             self._next_spawn_fails = True

--- a/tests/spawner/conftest.py
+++ b/tests/spawner/conftest.py
@@ -910,28 +910,30 @@ def mock_logger() -> object:
 
     return MockLogger()
 
-
 @pytest.fixture
-def mock_traci_wrapper() -> object:
-    class MockTraciWrapper:
-        """Mocks the TraCiWrapper."""
+def mock_train_spawner() -> object:
+    class MockTrainSpawner:
+        """Mocks the TrainSpawner."""
 
-        train: Train
+        identifier: str
+        timetable: list[str]
+        train_type: str
 
-        def spawn_train(self, train: Train):
-            self.train = train
-
-    return MockTraciWrapper()
+        def spawn_train(self, identifier: str, timetable: list[str], train_type: str):
+            self.identifier = identifier
+            self.timetable = timetable
+            self.train_type = train_type
+    return MockTrainSpawner()
 
 
 @pytest.fixture
 def spawner(
     spawner_configuration: SpawnerConfiguration,
     mock_logger: object,
-    mock_traci_wrapper: object,
+    mock_train_spawner: object,
 ) -> Spawner:
     return Spawner(
         configuration=spawner_configuration,
         logger=mock_logger,
-        traci_wrapper=mock_traci_wrapper,
+        train_spawner=mock_train_spawner,
     )

--- a/tests/spawner/conftest.py
+++ b/tests/spawner/conftest.py
@@ -910,6 +910,7 @@ def mock_logger() -> object:
 
     return MockLogger()
 
+
 @pytest.fixture
 def mock_train_spawner() -> object:
     class MockTrainSpawner:
@@ -918,11 +919,20 @@ def mock_train_spawner() -> object:
         identifier: str
         timetable: list[str]
         train_type: str
+        _next_spawn_fails: bool
+
+        def __init__(self):
+            self._next_spawn_fails = False
 
         def spawn_train(self, identifier: str, timetable: list[str], train_type: str):
             self.identifier = identifier
             self.timetable = timetable
             self.train_type = train_type
+            self._next_spawn_fails = False
+
+        def let_next_spawn_fail(self):
+            self._next_spawn_fails = True
+
     return MockTrainSpawner()
 
 

--- a/tests/spawner/conftest.py
+++ b/tests/spawner/conftest.py
@@ -924,7 +924,9 @@ def mock_train_spawner() -> object:
         def __init__(self):
             self._next_spawn_fails = False
 
-        def spawn_train(self, identifier: str, timetable: list[str], train_type: str) -> bool:
+        def spawn_train(
+            self, identifier: str, timetable: list[str], train_type: str
+        ) -> bool:
             if self._next_spawn_fails:
                 self._next_spawn_fails = False
                 return False

--- a/tests/spawner/conftest.py
+++ b/tests/spawner/conftest.py
@@ -919,10 +919,12 @@ def mock_train_spawner() -> object:
         identifier: str
         timetable: list[str]
         train_type: str
+        spawn_history: list[int]
         _next_spawn_fails: bool
 
         def __init__(self):
             self._next_spawn_fails = False
+            self.spawn_history = []
 
         def spawn_train(
             self, identifier: str, timetable: list[str], train_type: str
@@ -930,6 +932,7 @@ def mock_train_spawner() -> object:
             if self._next_spawn_fails:
                 self._next_spawn_fails = False
                 return False
+            self.spawn_history.append(int(identifier.split("_")[-1]))
             self.identifier = identifier
             self.timetable = timetable
             self.train_type = train_type

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -63,35 +63,24 @@ class TestSpawner:
                     == configuration.random_strategy_trains_per_1000_ticks
                 )
 
-    # This test fails due to unfixed bug #260
-    # It will be uncommented when the bug is fixed.
-
-    # @pytest.mark.usefixtures(
-    #     "spawner",
-    #     "strategy_start_tick",
-    #     "strategy_end_tick",
-    #     "regular_strategy_frequency",
-    #     "random_strategy_spawn_ticks",
-    #     "mock_traci_wrapper",
-    # )
-    # def test_next_tick(
-    #     self,
-    #     spawner: Spawner,
-    #     strategy_start_tick: int,
-    #     strategy_end_tick: int,
-    #     regular_strategy_frequency: int,
-    #     random_strategy_spawn_ticks: list[int],
-    #     mock_traci_wrapper: object,
-    # ):
-    #     regular_spawn_ticks = list(
-    #         range(
-    #             strategy_start_tick, strategy_end_tick + 1, regular_strategy_frequency
-    #         )
-    #     )
-    #     spawn_ticks = sorted(regular_spawn_ticks + random_strategy_spawn_ticks)
-    #     for tick in range(strategy_start_tick, strategy_end_tick + 1):
-    #         spawner.next_tick(tick)
-    #     assert mock_traci_wrapper.spawn_history == spawn_ticks
+    @pytest.mark.usefixtures(
+        "spawner",
+        "mock_train_spawner",
+        "strategy_start_tick",
+        "strategy_end_tick",
+        "regular_strategy_frequency",
+        "random_strategy_spawn_ticks"
+    )
+    def test_next_tick(self, spawner: Spawner, mock_train_spawner: object, strategy_start_tick: int, strategy_end_tick: int, regular_strategy_frequency: int, random_strategy_spawn_ticks: list[int]):
+        regular_spawn_ticks = list(
+            range(
+                strategy_start_tick, strategy_end_tick + 1, regular_strategy_frequency
+            )
+        )
+        spawn_ticks = sorted(regular_spawn_ticks + random_strategy_spawn_ticks)
+        for tick in range(strategy_start_tick, strategy_end_tick + 1):
+            spawner.next_tick(tick)
+        assert set(mock_train_spawner.spawn_history) == set(spawn_ticks)
 
 
 class TestSpawnerConfiguration:

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -69,9 +69,17 @@ class TestSpawner:
         "strategy_start_tick",
         "strategy_end_tick",
         "regular_strategy_frequency",
-        "random_strategy_spawn_ticks"
+        "random_strategy_spawn_ticks",
     )
-    def test_next_tick(self, spawner: Spawner, mock_train_spawner: object, strategy_start_tick: int, strategy_end_tick: int, regular_strategy_frequency: int, random_strategy_spawn_ticks: list[int]):
+    def test_next_tick(
+        self,
+        spawner: Spawner,
+        mock_train_spawner: object,
+        strategy_start_tick: int,
+        strategy_end_tick: int,
+        regular_strategy_frequency: int,
+        random_strategy_spawn_ticks: list[int],
+    ):
         regular_spawn_ticks = list(
             range(
                 strategy_start_tick, strategy_end_tick + 1, regular_strategy_frequency

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -1,3 +1,5 @@
+from itertools import zip_longest
+
 import pytest
 
 from src.schedule.random_schedule_strategy import RandomScheduleStrategy
@@ -88,7 +90,18 @@ class TestSpawner:
         spawn_ticks = sorted(regular_spawn_ticks + random_strategy_spawn_ticks)
         for tick in range(strategy_start_tick, strategy_end_tick + 1):
             spawner.next_tick(tick)
-        assert set(mock_train_spawner.spawn_history) == set(spawn_ticks)
+        assert all(
+            len(schedule._delayed_spawn_ticks) == 0
+            for schedule in spawner._schedules.values()
+        )
+        assert all(
+            history_tick == spawn_tick
+            for history_tick, spawn_tick in zip_longest(
+                sorted(mock_train_spawner.spawn_history),
+                sorted(spawn_ticks),
+                fillvalue=None,
+            )
+        )
 
 
 class TestSpawnerConfiguration:

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -19,18 +19,18 @@ class TestSpawner:
         pass
 
     @pytest.mark.usefixtures(
-        "spawner", "spawner_configuration", "mock_logger", "mock_traci_wrapper"
+        "spawner", "spawner_configuration", "mock_logger", "mock_train_spawner"
     )
     def test_creation_from_configuration(
         self,
         spawner: Spawner,
         spawner_configuration: SpawnerConfiguration,
         mock_logger: object,
-        mock_traci_wrapper: object,
+        mock_train_spawner: object,
     ):
         assert spawner.configuration == spawner_configuration
         assert spawner.logger == mock_logger
-        assert spawner.traci_wrapper == mock_traci_wrapper
+        assert spawner.train_spawner == mock_train_spawner
 
     @pytest.mark.usefixtures(
         "spawner",

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -91,7 +91,7 @@ class TestSpawner:
         for tick in range(strategy_start_tick, strategy_end_tick + 1):
             spawner.next_tick(tick)
         assert all(
-            len(schedule._delayed_spawn_ticks) == 0
+            len(schedule._ticks_to_be_spawned) == 0
             for schedule in spawner._schedules.values()
         )
         assert all(


### PR DESCRIPTION
Fixes #351 

Trains that are not able to be spawned because the track is blocked are saved to be spawned later.

## Wiki
- [Spawner](https://github.com/BP2022-AP1/bp2022-ap1/wiki/Spawner)

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] ~~Added classes that inherit from `BaseModel` to `src.constants.tables`~~
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
