### PR TITLE
Make `_make` method in `Schema` of `FaultConfiguration` abstract

### DIFF
--- a/src/fault_injector/fault_configurations/fault_configuration.py
+++ b/src/fault_injector/fault_configurations/fault_configuration.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+
 import marshmallow as marsh
 from peewee import IntegerField, TextField
 
@@ -14,8 +16,9 @@ class FaultConfiguration(BaseModel):
         end_tick = marsh.fields.Integer(required=True)
         description = marsh.fields.String()
 
+        @abstractmethod
         def _make(self, data: dict) -> "FaultConfiguration":
-            return FaultConfiguration(**data)
+            raise NotImplementedError()
 
     start_tick = IntegerField(null=False)
     end_tick = IntegerField(null=False)


### PR DESCRIPTION
Fixes #397 

Changes the mentioned mathod to abstract since all child classes implement the method and `FaultConfiguration` should not be used.

## PR checklist

- [ ] Acceptance criteria fulfilled
- [ ] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
