### PR TITLE
Fix: Remove foreign keys to token from simulation configuration

### DIFF
--- a/postman/schemas/index.yaml
+++ b/postman/schemas/index.yaml
@@ -43,7 +43,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of schedules connected to a user.
+      summary: Get ids of schedules.
 
     post:
       operationId: create_schedule
@@ -134,7 +134,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of schedule-blocked-faul configurations connected to a user.
+      summary: Get ids of schedule-blocked-faul configurations.
 
     post:
       operationId: create_schedule_blocked_fault_configuration
@@ -230,7 +230,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of track-blocked-fault configurations connected to a user.
+      summary: Get ids of track-blocked-fault configurations.
 
     post:
       operationId: create_track_blocked_fault_configuration
@@ -326,7 +326,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of track-speed-limit-fault configurations connected to a user.
+      summary: Get ids of track-speed-limit-fault configurations.
 
     post:
       operationId: create_track_speed_limit_fault_configuration
@@ -422,7 +422,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of train-prio-fault configurations connected to a user.
+      summary: Get ids of train-prio-fault configurations.
 
     post:
       operationId: create_train_prio_fault_configuration
@@ -516,7 +516,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of train-speed-fault configurations connected to a user.
+      summary: Get ids of train-speed-fault configurations.
 
     post:
       operationId: create_train_speed_fault_configuration
@@ -610,7 +610,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of platform-blocked-fault configurations connected to a user.
+      summary: Get ids of platform-blocked-fault configurations.
 
     post:
       operationId: create_platform_blocked_fault_configuration
@@ -704,7 +704,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of interlocking configurations connected to a user.
+      summary: Get ids of interlocking configurations.
 
     post:
       operationId: create_interlocking_configuration
@@ -800,7 +800,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation not found
-      summary: Get ids of spawner configurations connected to a user.
+      summary: Get ids of spawner configurations.
 
     post:
       operationId: create_spawner_configuration
@@ -893,7 +893,7 @@ paths:
           description: API token missing
         "404":
           description: Simulation id not found
-      summary: Get all ids of runs connected to a user and a simulation.
+      summary: Get all ids of runs and a simulation.
 
     post:
       operationId: create_run
@@ -982,7 +982,7 @@ paths:
           description: Successful operation
         "401":
           description: API token missing
-      summary: Get all ids of simulation configurations connected to a user.
+      summary: Get all ids of simulation configurations.
 
     post:
       operationId: create_simulation_configuration
@@ -1053,7 +1053,7 @@ paths:
       summary:
         "Get all information about a simulation, including the ids of connected\
         \ components and runs."
-    
+
     put:
       operationId: update_simulation_configuration
       parameters:

--- a/src/implementor/models.py
+++ b/src/implementor/models.py
@@ -28,13 +28,11 @@ class SimulationConfiguration(BaseModel):
         """The marshmallow schema for the simulation configuration model."""
 
         description = marsh.fields.String()
-        token = marsh.fields.UUID(required=True)
 
         def _make(self, data: dict) -> "SimulationConfiguration":
             return SimulationConfiguration(**data)
 
     description = CharField(null=True)
-    token = ForeignKeyField(Token, backref="simulation_configurations")
 
 
 class Run(BaseModel):

--- a/tests/implementor/test_table_simulation_configuration.py
+++ b/tests/implementor/test_table_simulation_configuration.py
@@ -22,7 +22,7 @@ class TestSimulationConfigurationFailingInit:
     def test_create(self, init_dict: dict):
         """Test that an object of a class cannot be saved."""
         with pytest.raises(peewee.IntegrityError):
-            SimulationConfiguration(init_dict).save(force_insert=True)
+            SimulationConfiguration(**init_dict).save(force_insert=True)
 
     @pytest.mark.parametrize(
         "init_dict",
@@ -31,7 +31,7 @@ class TestSimulationConfigurationFailingInit:
     def test_deserialization(self, init_dict: dict):
         """Test that an object of a class cannot be deserialized."""
         with pytest.raises(marsh.exceptions.ValidationError):
-            SimulationConfiguration.Schema().load({**init_dict})
+            SimulationConfiguration.Schema().load(**init_dict)
 
 
 class TestSimulationConfigurationSuccessfulInit:

--- a/tests/implementor/test_table_simulation_configuration.py
+++ b/tests/implementor/test_table_simulation_configuration.py
@@ -4,7 +4,7 @@ import marshmallow as marsh
 import peewee
 import pytest
 
-from src.implementor.models import SimulationConfiguration, Token
+from src.implementor.models import SimulationConfiguration
 from tests.decorators import recreate_db_setup
 
 
@@ -17,28 +17,21 @@ class TestSimulationConfigurationFailingInit:
 
     @pytest.mark.parametrize(
         "init_dict",
-        [
-            {  # token does not exists
-                "token": "00000000-0000-0000-0000-000000000000",
-            },
-            {},  # token is missing
-        ],
+        [],
     )
     def test_create(self, init_dict: dict):
         """Test that an object of a class cannot be saved."""
         with pytest.raises(peewee.IntegrityError):
-            SimulationConfiguration(**init_dict).save(force_insert=True)
+            SimulationConfiguration(init_dict).save(force_insert=True)
 
     @pytest.mark.parametrize(
         "init_dict",
-        [
-            {},  # token is missing
-        ],
+        [],
     )
     def test_deserialization(self, init_dict: dict):
         """Test that an object of a class cannot be deserialized."""
         with pytest.raises(marsh.exceptions.ValidationError):
-            SimulationConfiguration.Schema().load(init_dict)
+            SimulationConfiguration.Schema().load({**init_dict})
 
 
 class TestSimulationConfigurationSuccessfulInit:
@@ -47,12 +40,6 @@ class TestSimulationConfigurationSuccessfulInit:
     @recreate_db_setup
     def setup_method(self):
         pass
-
-    @pytest.fixture
-    def token(self):
-        token = Token(name="owner", permission="admin", hashedToken="hash")
-        token.save()
-        return token
 
     @pytest.mark.parametrize(
         "init_dict",
@@ -63,17 +50,12 @@ class TestSimulationConfigurationSuccessfulInit:
             {},
         ],
     )
-    def test_create(self, init_dict: dict, token: Token):
+    def test_create(self, init_dict: dict):
         """Test that a object of a class can be created."""
-        obj = SimulationConfiguration(
-            **init_dict,
-            token=token.id,
-        )
+        obj = SimulationConfiguration(**init_dict)
         obj.save(force_insert=True)
         assert isinstance(obj, SimulationConfiguration)
         assert isinstance(obj.id, UUID)
-        assert isinstance(obj.token, Token)
-        assert obj.token == token
         assert (
             SimulationConfiguration.select()
             .where(SimulationConfiguration.id == obj.id)
@@ -97,17 +79,14 @@ class TestSimulationConfigurationSuccessfulInit:
             ({}, {"description": None}),
         ],
     )
-    def test_serialization(self, init_values: dict, expected_dict: dict, token: Token):
+    def test_serialization(self, init_values: dict, expected_dict: dict):
         """Test that an object of a class can be serialized."""
         obj = SimulationConfiguration(
             **init_values,
-            token=token.id,
         )
 
         serialized_obj = obj.to_dict()
         assert isinstance(serialized_obj["id"], str)
-        assert isinstance(serialized_obj["token"], str)
-        assert serialized_obj["token"] == str(token.id)
         for key in expected_dict.keys():
             assert serialized_obj[key] == expected_dict[key]
 
@@ -125,15 +104,11 @@ class TestSimulationConfigurationSuccessfulInit:
             ({}, {"description": None}),
         ],
     )
-    def test_deserialization(
-        self, init_dict: dict, expected_values: dict, token: Token
-    ):
+    def test_deserialization(self, init_dict: dict, expected_values: dict):
         """Test that an object of a class can be deserialized."""
-        obj = SimulationConfiguration.Schema().load({**init_dict, "token": token.id})
+        obj = SimulationConfiguration.Schema().load({**init_dict})
         assert isinstance(obj, SimulationConfiguration)
         assert isinstance(obj.id, UUID)
-        assert isinstance(obj.token, Token)
-        assert obj.token == token
         for key in expected_values.keys():
             assert getattr(obj, key) == expected_values[key]
 

--- a/tests/interlocking_component/conftest.py
+++ b/tests/interlocking_component/conftest.py
@@ -14,8 +14,8 @@ def token() -> Token:
 
 
 @pytest.fixture
-def simulation_configuration(token) -> SimulationConfiguration:
-    config = SimulationConfiguration(token=token)
+def simulation_configuration() -> SimulationConfiguration:
+    config = SimulationConfiguration()
     config.save()
     return config
 

--- a/tests/logger/conftest.py
+++ b/tests/logger/conftest.py
@@ -47,8 +47,8 @@ def token():
 
 
 @pytest.fixture
-def simulation_configuration(token):
-    return SimulationConfiguration.create(token=token.id)
+def simulation_configuration():
+    return SimulationConfiguration.create()
 
 
 @pytest.fixture

--- a/tests/spawner/conftest.py
+++ b/tests/spawner/conftest.py
@@ -780,7 +780,7 @@ def token() -> Token:
 
 
 @pytest.fixture
-def simulation_configuration(token) -> SimulationConfiguration:
-    config = SimulationConfiguration(token=token)
+def simulation_configuration() -> SimulationConfiguration:
+    config = SimulationConfiguration()
     config.save()
     return config


### PR DESCRIPTION
Fixes #<n>

Removes foreign key from simulation configuration to token in order to make the simulation configurations available for everyone with a token.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
