### PR TITLE
Feature: Add functionality of /simulation route

### DIFF
--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -38,6 +38,13 @@ class SimulationConfiguration(Schema):
     """The marshmallow schema for the simulation configuration model."""
 
     description = fields.String()
+    spawner = fields.UUID(required=True)
+    platform_blocked_fault = fields.List(fields.UUID())
+    schedule_blocked_fault = fields.List(fields.UUID())
+    track_blocked_fault = fields.List(fields.UUID())
+    track_speed_limit_fault = fields.List(fields.UUID())
+    train_speed_fault = fields.List(fields.UUID())
+    train_prio_fault = fields.List(fields.UUID())
 
 
 class SpawnerConfiguration(Schema):

--- a/src/implementor/simulation.py
+++ b/src/implementor/simulation.py
@@ -1,7 +1,30 @@
 # pylint: disable=unused-argument
 # pylint: disable=duplicate-code
-
 import json
+
+import peewee
+
+from src.base_model import BaseModel, db
+from src.fault_injector.fault_configurations.platform_blocked_fault_configuration import (
+    PlatformBlockedFaultConfigurationXSimulationConfiguration,
+)
+from src.fault_injector.fault_configurations.schedule_blocked_fault_configuration import (
+    ScheduleBlockedFaultConfigurationXSimulationConfiguration,
+)
+from src.fault_injector.fault_configurations.track_blocked_fault_configuration import (
+    TrackBlockedFaultConfigurationXSimulationConfiguration,
+)
+from src.fault_injector.fault_configurations.track_speed_limit_fault_configuration import (
+    TrackSpeedLimitFaultConfigurationXSimulationConfiguration,
+)
+from src.fault_injector.fault_configurations.train_prio_fault_configuration import (
+    TrainPrioFaultConfigurationXSimulationConfiguration,
+)
+from src.fault_injector.fault_configurations.train_speed_fault_configuration import (
+    TrainSpeedFaultConfigurationXSimulationConfiguration,
+)
+from src.implementor.models import SimulationConfiguration
+from src.spawner.spawner import SpawnerConfigurationXSimulationConfiguration
 
 
 def get_all_simulation_ids(token):
@@ -11,10 +34,8 @@ def get_all_simulation_ids(token):
     :param token: Token object of the current user
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
-
-    return json.dumps(""), 501  # 200
+    simulations = [str(sim.id) for sim in SimulationConfiguration.select()]
+    return simulations, 200
 
 
 def create_simulation_configuration(body, token):
@@ -24,17 +45,117 @@ def create_simulation_configuration(body, token):
     :param token: Token object of the current user
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
+    def check_and_create_configuration_references(
+        simulation: SimulationConfiguration,
+        key: str,
+        table: BaseModel,
+        column: str,
+    ):
+        """
+        Create the references between the simulation configuration
+        and the component configuration given the list of configuration ids.
+        """
+        if key in body:
+            configuration_ids = body[key]
+            for configuration_id in configuration_ids:
+                table.create(
+                    **{
+                        "simulation_configuration": simulation,
+                        column: configuration_id,
+                    }
+                )
 
-    return (
-        json.dumps(
-            {
-                "id": "<uuid>",
+    try:
+        with db.atomic():
+            simulation = SimulationConfiguration()
+            simulation.save()
+
+            # Add references between simulation configuration and spawner
+            spawner_configuration = body["spawner"]
+            SpawnerConfigurationXSimulationConfiguration.create(
+                simulation_configuration=simulation,
+                spawner_configuration=spawner_configuration,
+            )
+
+            # Add references between simulation configuration and platform blocked fault
+            platform_blocked_fault = {
+                "key": "platform_blocked_fault",
+                "column": "platform_blocked_fault_configuration",
             }
-        ),
-        501,  # 201,
-    )
+            check_and_create_configuration_references(
+                simulation,
+                platform_blocked_fault["key"],
+                PlatformBlockedFaultConfigurationXSimulationConfiguration,
+                platform_blocked_fault["column"],
+            )
+
+            # Add references between simulation configuration and schedule blocked fault
+            schedule_blocked_fault = {
+                "key": "schedule_blocked_fault",
+                "column": "schedule_blocked_fault_configuration",
+            }
+            check_and_create_configuration_references(
+                simulation,
+                schedule_blocked_fault["key"],
+                ScheduleBlockedFaultConfigurationXSimulationConfiguration,
+                schedule_blocked_fault["column"],
+            )
+
+            # Add references between simulation configuration and track blocked fault
+            track_blocked_fault = {
+                "key": "track_blocked_fault",
+                "column": "track_blocked_fault_configuration",
+            }
+            check_and_create_configuration_references(
+                simulation,
+                track_blocked_fault["key"],
+                TrackBlockedFaultConfigurationXSimulationConfiguration,
+                track_blocked_fault["column"],
+            )
+
+            # Add references between simulation configuration and track speed limit fault
+            track_speed_limit_fault = {
+                "key": "track_speed_limit_fault",
+                "column": "track_speed_limit_fault_configuration",
+            }
+            check_and_create_configuration_references(
+                simulation,
+                track_speed_limit_fault["key"],
+                TrackSpeedLimitFaultConfigurationXSimulationConfiguration,
+                track_speed_limit_fault["column"],
+            )
+
+            # Add references between simulation configuration and train prio fault
+            train_prio_fault = {
+                "key": "train_prio_fault",
+                "column": "train_prio_fault_configuration",
+            }
+            check_and_create_configuration_references(
+                simulation,
+                train_prio_fault["key"],
+                TrainPrioFaultConfigurationXSimulationConfiguration,
+                train_prio_fault["column"],
+            )
+
+            # Add references between simulation configuration and train speed fault
+            train_speed_fault = {
+                "key": "train_speed_fault",
+                "column": "train_speed_fault_configuration",
+            }
+            check_and_create_configuration_references(
+                simulation,
+                train_speed_fault["key"],
+                TrainSpeedFaultConfigurationXSimulationConfiguration,
+                train_speed_fault["column"],
+            )
+
+            return {"id": str(simulation.id)}, 201
+
+    except peewee.IntegrityError:
+        return (
+            {"error": "Configuration not found"},
+            404,
+        )
 
 
 def get_simulation_configuration(options, token):

--- a/tests/api/test_api_simulation.py
+++ b/tests/api/test_api_simulation.py
@@ -14,14 +14,29 @@ class TestApiSimulation:
         response = client.get("/simulation", headers={TOKEN_HEADER: clear_token})
         assert response.status_code == 501
 
-    @pytest.mark.parametrize("data", [{}])
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"spawner": uuid.uuid4()},
+            {
+                "spawner": uuid.uuid4(),
+                "description": "test-description",
+                "platform_blocked_fault": [uuid.uuid4()],
+                "schedule_blocked_fault": [uuid.uuid4()],
+                "track_blocked_fault": [uuid.uuid4()],
+                "track_speed_limit_fault": [uuid.uuid4()],
+                "train_speed_fault": [uuid.uuid4()],
+                "train_prio_fault": [uuid.uuid4()],
+            },
+        ],
+    )
     def test_post(self, client, clear_token, data):
         response = client.post(
             "/simulation", headers={TOKEN_HEADER: clear_token}, json=data
         )
         assert response.status_code != 422
 
-    @pytest.mark.parametrize("data", [])
+    @pytest.mark.parametrize("data", [{}])
     def test_post_invalid(self, client, clear_token, data):
         response = client.post(
             "/simulation", headers={TOKEN_HEADER: clear_token}, json=data
@@ -40,7 +55,7 @@ class TestApiSimulation:
         response = client.put(
             f"/simulation/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 501
+        assert response.status_code == 422  # temporary
 
     def test_delete(self, client, clear_token):
         object_id = uuid.uuid4()

--- a/tests/api/test_api_simulation.py
+++ b/tests/api/test_api_simulation.py
@@ -12,7 +12,7 @@ class TestApiSimulation:
 
     def test_get_all(self, client, clear_token):
         response = client.get("/simulation", headers={TOKEN_HEADER: clear_token})
-        assert response.status_code == 501
+        assert response.status_code == 200
 
     @pytest.mark.parametrize(
         "data",

--- a/tests/api/test_decorator.py
+++ b/tests/api/test_decorator.py
@@ -8,7 +8,7 @@ TOKEN_HEADER = "bp2022-ap1-api-key"
     [
         ("/run", 200),
         ("/schedule", 501),
-        ("/simulation", 501),
+        ("/simulation", 200),
         ("/component/interlocking", 501),
         ("/component/spawner", 501),
         ("/component/fault-injection/schedule-blocked-fault", 501),

--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -325,7 +325,6 @@ def train_speed_fault_configuration(train_speed_fault_configuration_data):
 
 @pytest.fixture
 def simulation_configuration_data(
-    interlocking_configuration,
     spawner_configuration,
     platform_blocked_fault_configuration,
     schedule_blocked_fault_configuration,
@@ -335,8 +334,7 @@ def simulation_configuration_data(
     train_speed_fault_configuration,
 ):
     return {
-        "interlocking": [interlocking_configuration.id],
-        "spawner": [spawner_configuration.id],
+        "spawner": spawner_configuration.id,
         "platform_blocked_fault": [platform_blocked_fault_configuration.id],
         "schedule_blocked_fault": [schedule_blocked_fault_configuration.id],
         "track_blocked_fault": [track_blocked_fault_configuration.id],
@@ -356,14 +354,19 @@ def simulation_configuration_full(
 
 
 @pytest.fixture
-def empty_simulation_configuration():
-    simulation = SimulationConfiguration()
+def empty_simulation_configuration_data(spawner_configuration):
+    return {"spawner": [spawner_configuration.id]}
+
+
+@pytest.fixture
+def empty_simulation_configuration(empty_simulation_configuration_data):
+    simulation = SimulationConfiguration(**empty_simulation_configuration_data)
     simulation.save()
     return simulation
 
 
 @pytest.fixture
-def another_empty_simulation_configuration():
-    simulation = SimulationConfiguration()
+def another_empty_simulation_configuration(empty_simulation_configuration_data):
+    simulation = SimulationConfiguration(**empty_simulation_configuration_data)
     simulation.save()
     return simulation

--- a/tests/implementor/test_impl_simulation.py
+++ b/tests/implementor/test_impl_simulation.py
@@ -1,0 +1,64 @@
+import uuid
+
+from src import implementor as impl
+from src.implementor.models import SimulationConfiguration
+
+
+class TestSimulationImplementor:
+    def test_get_all_simulation_ids(self, token, empty_simulation_configuration_data):
+        simulation = SimulationConfiguration.create(
+            **empty_simulation_configuration_data
+        )
+        result, status = impl.simulation.get_all_simulation_ids(token)
+        assert status == 200
+        assert str(simulation.id) in result
+
+    def test_post(self, token, simulation_configuration_data: dict):
+        result, status = impl.simulation.create_simulation_configuration(
+            simulation_configuration_data,
+            token,
+        )
+        assert status == 201
+        simulation_configuration_id = result["id"]
+        simulation_configuration = (
+            SimulationConfiguration.select()
+            .where(SimulationConfiguration.id == simulation_configuration_id)
+            .get()
+        )
+
+        def verify_references(key: str):
+            """
+            Verifies that the references between the simulation configuration and the component configuration exist
+            :param key: The key of the component configuration
+            """
+            assert set(simulation_configuration_data[key]) == set(
+                [
+                    getattr(reference, f"{key}_configuration").id
+                    for reference in getattr(
+                        simulation_configuration, f"{key}_configuration_references"
+                    )
+                ]
+            )
+
+        verify_references("platform_blocked_fault")
+        verify_references("schedule_blocked_fault")
+        verify_references("track_blocked_fault")
+        verify_references("track_speed_limit_fault")
+        verify_references("train_prio_fault")
+        verify_references("train_speed_fault")
+
+        spawner_ids = [
+            reference.spawner_configuration.id
+            for reference in simulation_configuration.spawner_configuration_references
+        ]
+        assert len(spawner_ids) == 1
+        assert spawner_ids[0] == simulation_configuration_data["spawner"]
+
+    def test_post_invalid_not_found(self, token):
+        simulation_configuration_data = {"spawner": uuid.uuid4()}
+        result, status = impl.simulation.create_simulation_configuration(
+            simulation_configuration_data,
+            token,
+        )
+        assert status == 404
+        assert result["error"] == "Configuration not found"


### PR DESCRIPTION
Fixes #195 

This PR adds functionality to the /simulation route, tests and adds the validation of the route /simulation.
The implementor tries to create references between the simulation and component configurations.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
