### PR TITLE
Feature add functionality to /component/fault-injection/track-speed-limit-fault route

### DIFF
--- a/postman/collections/rest-api-autogenerate.json
+++ b/postman/collections/rest-api-autogenerate.json
@@ -4731,7 +4731,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{}",
+											"raw": "{\n    \"start_tick\": 4,\n    \"end_tick\": 130,\n    \"description\": \"\",\n    \"affected_element_id\": \"<uuid>\",\n    \"new_speed_limit\": 60,\n    \"strategy\": \"regular\",\n    \"inject_probability\": 0.9,\n    \"resolve_probability\": 0.9\n}",
 											"options": {
 												"raw": {
 													"headerFamily": "json",
@@ -5061,7 +5061,7 @@
 												}
 											],
 											"cookie": [],
-											"body": "{}"
+											"body": "{\n  \"new_speed_limit\": \"<integer>\",\n  \"description\": \"<string>\",\n  \"strategy\": \"random\"\n}"
 										},
 										{
 											"id": "73c3eadc-3911-45c9-930e-bb5fefc1aa14",

--- a/postman/schemas/index.yaml
+++ b/postman/schemas/index.yaml
@@ -1123,6 +1123,36 @@ components:
       type: object
     TrackSpeedLimitFaultConfiguration:
       type: object
+      required:
+        - new_speed_limit
+        - description
+        - strategy
+      properties:
+        start_tick:
+          type: integer
+          format: int32
+        end_tick:
+          type: integer
+          format: int32
+        inject_probability:
+          type: number
+          format: float
+        resolve_probability:
+          type: number
+          format: float
+        description:
+          type: string
+        affected_element_id:
+          type: string
+          format: uuid
+        new_speed_limit:
+          type: integer
+          format: int32
+        strategy:
+          type: string
+          enum:
+            - regular
+            - random
     TrackBlockedFaultConfiguration:
       type: object
     PlatformBlockedFaultConfiguration:

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -54,12 +54,12 @@ class TokenConfiguration(Schema):
 class FaultConfiguration(Schema):
     """Schema for the FaultConfiguration"""
 
-    start_tick = fields.Integer(required=False)
-    end_tick = fields.Integer(required=False)
-    inject_probability = fields.Float(required=False)
-    resolve_probability = fields.Float(required=False)
-    description = fields.String()
-    strategy = fields.String()
+    start_tick = fields.Integer()
+    end_tick = fields.Integer()
+    inject_probability = fields.Float()
+    resolve_probability = fields.Float()
+    description = fields.String(required=True)
+    strategy = fields.String(required=True)
 
 
 class TrackBlockedFaultConfiguration(FaultConfiguration):
@@ -71,7 +71,7 @@ class TrackBlockedFaultConfiguration(FaultConfiguration):
 class TrackSpeedLimitFaultConfiguration(FaultConfiguration):
     """Schema for TrackSpeedLimitFaultConfiguration"""
 
-    affected_element_id = fields.String()
+    affected_element_id = fields.String(required=True)
     new_speed_limit = fields.Integer(required=True)
 
 

--- a/src/implementor/component.py
+++ b/src/implementor/component.py
@@ -3,6 +3,11 @@
 
 import json
 
+from src.fault_injector.fault_configurations.track_speed_limit_fault_configuration import (
+    TrackSpeedLimitFaultConfiguration,
+)
+from src.implementor.models import SimulationConfiguration
+
 
 def get_all_schedule_blocked_fault_configuration_ids(options, token):
     """
@@ -139,10 +144,29 @@ def get_all_track_speed_limit_fault_configuration_ids(options, token):
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
+    # Return all track speed limit fault configurations of a single simulation configuration
+    if options["simulationId"] is not None:
+        simulation_id = options["simulationId"]
+        simulation_configurations = SimulationConfiguration.select().where(
+            SimulationConfiguration.id == simulation_id
+        )
+        if not simulation_configurations.exists():
+            return "Simulation not found", 404
 
-    return json.dumps(""), 501  # 200
+        simulation_configuration = simulation_configurations.get()
+        references = (
+            simulation_configuration.track_speed_limit_fault_configuration_references
+        )
+
+        configs = [
+            str(reference.track_speed_limit_fault_configuration.id)
+            for reference in references
+        ]
+        return configs, 200
+
+    # Return all track speed limit fault configurations
+    configs = [str(config.id) for config in TrackSpeedLimitFaultConfiguration.select()]
+    return configs, 200
 
 
 def create_track_speed_limit_fault_configuration(body, token):
@@ -154,14 +178,12 @@ def create_track_speed_limit_fault_configuration(body, token):
 
     # Implement your business logic here
     # All the parameters are present in the options argument
-
+    config = TrackSpeedLimitFaultConfiguration.create(**body)
     return (
-        json.dumps(
-            {
-                "id": "<uuid>",
-            }
-        ),
-        501,  # 201,
+        {
+            "id": config.id,
+        },
+        201,
     )
 
 

--- a/tests/api/test_api_platform_blocked_fault.py
+++ b/tests/api/test_api_platform_blocked_fault.py
@@ -20,7 +20,7 @@ class TestApiPlatformBlockedFault:
     @pytest.mark.parametrize(
         "data",
         [
-            {"affected_element_id": "test"},
+            {"affected_element_id": "test", "description": "test", "strategy": "test"},
             {
                 "affected_element_id": "test",
                 "start_tick": 1,

--- a/tests/api/test_api_schedule_blocked_fault.py
+++ b/tests/api/test_api_schedule_blocked_fault.py
@@ -20,7 +20,7 @@ class TestApiScheduleBlockedFault:
     @pytest.mark.parametrize(
         "data",
         [
-            {"affected_element_id": "test"},
+            {"affected_element_id": "test", "description": "test", "strategy": "test"},
             {
                 "affected_element_id": "test",
                 "start_tick": 1,

--- a/tests/api/test_api_track_blocked_fault.py
+++ b/tests/api/test_api_track_blocked_fault.py
@@ -20,7 +20,7 @@ class TestApiTrackBlockedFault:
     @pytest.mark.parametrize(
         "data",
         [
-            {"affected_element_id": "test"},
+            {"affected_element_id": "test", "description": "test", "strategy": "test"},
             {
                 "affected_element_id": "test",
                 "start_tick": 1,

--- a/tests/api/test_api_track_speed_limit_fault.py
+++ b/tests/api/test_api_track_speed_limit_fault.py
@@ -20,7 +20,12 @@ class TestApiTrackSpeedLimitFault:
     @pytest.mark.parametrize(
         "data",
         [
-            {"new_speed_limit": 1},
+            {
+                "new_speed_limit": 1,
+                "description": "test",
+                "strategy": "test",
+                "affected_element_id": "test",
+            },
             {
                 "affected_element_id": "test",
                 "new_speed_limit": 1,

--- a/tests/api/test_api_track_speed_limit_fault.py
+++ b/tests/api/test_api_track_speed_limit_fault.py
@@ -15,7 +15,7 @@ class TestApiTrackSpeedLimitFault:
             "/component/fault-injection/track-speed-limit-fault",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 501
+        assert response.status_code == 200
 
     @pytest.mark.parametrize(
         "data",

--- a/tests/api/test_api_train_prio_limit.py
+++ b/tests/api/test_api_train_prio_limit.py
@@ -20,7 +20,7 @@ class TestApiTrainPrioFault:
     @pytest.mark.parametrize(
         "data",
         [
-            {"new_prio": 1},
+            {"new_prio": 1, "description": "test", "strategy": "test"},
             {
                 "affected_element_id": "test",
                 "new_prio": 1,

--- a/tests/api/test_api_train_speed_fault.py
+++ b/tests/api/test_api_train_speed_fault.py
@@ -20,7 +20,12 @@ class TestApiTrainSpeedFault:
     @pytest.mark.parametrize(
         "data",
         [
-            {"new_speed": 0.1, "affected_element_id": "test"},
+            {
+                "new_speed": 0.1,
+                "affected_element_id": "test",
+                "description": "test",
+                "strategy": "test",
+            },
             {
                 "affected_element_id": "test",
                 "new_speed": 0.1,

--- a/tests/api/test_decorator.py
+++ b/tests/api/test_decorator.py
@@ -16,7 +16,7 @@ TOKEN_HEADER = "bp2022-ap1-api-key"
         ("/component/fault-injection/track-blocked-fault", 501),
         ("/component/fault-injection/train-prio-fault", 501),
         ("/component/fault-injection/train-speed-fault", 501),
-        ("/component/fault-injection/track-speed-limit-fault", 501),
+        ("/component/fault-injection/track-speed-limit-fault", 200),
         ("/run/1", 501),
         ("/schedule/1", 501),
         ("/simulation/1", 501),

--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+
+from src.fault_injector.fault_configurations.track_speed_limit_fault_configuration import (
+    TrackSpeedLimitFaultConfiguration,
+)
+from src.implementor.models import SimulationConfiguration
+from src.wrapper.simulation_objects import Edge, Track
+
+# ------------- TrackSpeedLimitFaultConfiguration ----------------
+
+
+@pytest.fixture
+def edge() -> Edge:
+    return Edge("fault injector track")
+
+
+@pytest.fixture
+def edge_re() -> Edge:
+    return Edge("fault injector track-re")
+
+
+@pytest.fixture
+def track(edge, edge_re):
+    return Track(edge, edge_re)
+
+
+@pytest.fixture
+def track_speed_limit_fault_configuration_data(
+    track: Track,
+) -> dict:
+    return {
+        "start_tick": 4,
+        "end_tick": 130,
+        "description": "test TrackSpeedLimitFault",
+        "affected_element_id": track.identifier,
+        "new_speed_limit": 60,
+        "strategy": "regular",
+    }
+
+
+@pytest.fixture
+def track_speed_limit_fault_configuration(
+    track_speed_limit_fault_configuration_data: dict,
+) -> TrackSpeedLimitFaultConfiguration:
+    return TrackSpeedLimitFaultConfiguration.create(
+        track_speed_limit_fault_configuration_data
+    )
+
+
+# ------------- SimulationConfiguration ----------------
+
+
+@pytest.fixture
+def empty_simulation_configuration():
+    simulation = SimulationConfiguration()
+    simulation.save()
+    return simulation

--- a/tests/implementor/test_impl_track_speed_limit_fault.py
+++ b/tests/implementor/test_impl_track_speed_limit_fault.py
@@ -1,0 +1,66 @@
+from src import implementor as impl
+from src.fault_injector.fault_configurations.track_speed_limit_fault_configuration import (
+    TrackSpeedLimitFaultConfiguration,
+    TrackSpeedLimitFaultConfigurationXSimulationConfiguration,
+)
+
+
+class TestRunImplementor:
+    def test_get_all_track_speed_limit_fault_configuration_ids(
+        self, token, track_speed_limit_fault_configuration_data
+    ):
+        config = TrackSpeedLimitFaultConfiguration.create(
+            **track_speed_limit_fault_configuration_data
+        )
+
+        response = impl.component.get_all_track_speed_limit_fault_configuration_ids(
+            {}, token
+        )
+        (result, status) = response
+        assert status == 200
+        assert str(config.id) in result
+
+    def test_get_all_track_speed_limit_fault_configuration_ids(
+        self,
+        token,
+        track_speed_limit_fault_configuration_data,
+        empty_simulation_configuration,
+    ):
+        config = TrackSpeedLimitFaultConfiguration.create(
+            **track_speed_limit_fault_configuration_data
+        )
+        another_config = TrackSpeedLimitFaultConfiguration.create(
+            **track_speed_limit_fault_configuration_data
+        )
+        TrackSpeedLimitFaultConfigurationXSimulationConfiguration.create(
+            simulation_configuration=empty_simulation_configuration,
+            track_speed_limit_fault_configuration=config,
+        )
+
+        response = impl.component.get_all_track_speed_limit_fault_configuration_ids(
+            {"simulationId": str(empty_simulation_configuration.id)}, token
+        )
+        (result, status) = response
+
+        assert status == 200
+        assert str(config.id) in result
+        assert str(another_config.id) not in result
+
+    def test_create_track_speed_limit_fault_configuration(
+        token, track_speed_limit_fault_configuration_data
+    ):
+        response = impl.component.create_track_speed_limit_fault_configuration(
+            track_speed_limit_fault_configuration_data, token
+        )
+        (result, status) = response
+        assert status == 201
+        assert result["id"]
+        configs = TrackSpeedLimitFaultConfiguration.select().where(
+            TrackSpeedLimitFaultConfiguration.id == result["id"]
+        )
+        assert configs.exists()
+        config = configs.get()
+        for key in track_speed_limit_fault_configuration_data:
+            assert (
+                getattr(config, key) == track_speed_limit_fault_configuration_data[key]
+            )


### PR DESCRIPTION
Fixes #200 

Add functionality to /component/fault-injection/track-speed-limit-fault route with methods POST and GET. Updates openAPI3 definition and request collection. Adds tests.

Additionally, I had to align the marshmallow schema with the peewee schema of the fault configurations.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
