### PR TITLE
Feature: Add possibility to see simulation visually

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,20 @@ build-backend = "poetry.core.masonry.api"
     cmd = "docker compose up prod"
     envfile = ".env.secret"
 
+    [tool.poe.tasks.gui]
+    help = "Run flask app in development mode with gui"
+    sequence = ["gui-deps", "sleep", "gui-flask"]
+    envfile = [".env.shared", ".env.secret"]
+
+    [tool.poe.tasks.gui-deps]
+    help = "Run database and grafana for gui"
+    cmd = "docker compose up postgresql grafana-dev -d"
+
+    [tool.poe.tasks.gui-flask]
+    help = "Run flask app in development mode with gui"
+    cmd = "flask -A src run --debug"
+    env = { "DISABLE_CELERY" = "true" }
+
     [tool.poe.tasks.cov]
     help = "Run coverage report"
     cmd = "pytest --co --cov=src --cov-config=.coveragerc"

--- a/src/communicator/celery.py
+++ b/src/communicator/celery.py
@@ -1,0 +1,53 @@
+import os
+
+from celery import Celery
+
+
+class CeleryClientDummy:
+    """Dummy class for celery if it is disabled"""
+
+    def task(self, *args, **kwargs):
+        """Dummy task function"""
+        return lambda x: CeleryTaskDummy()
+
+
+class CeleryTaskDummy:
+    """Dummy class for celery if it is disabled"""
+
+    def delay(self, *args, **kwargs):
+        """Dummy delay function"""
+        return CeleryResponseDummy()
+
+
+class CeleryResponseDummy:
+    """Dummy class for celery if it is disabled"""
+
+    id = None
+
+
+def build_celery():
+    """
+    Builds a celery client if it is not disabled.
+    Otherwise it returns a dummy client.
+
+    :return: A celery client or dummy client
+    """
+    if os.getenv("DISABLE_CELERY", False):
+        return CeleryClientDummy()
+    celery = Celery(
+        "proj",
+        broker=os.getenv("CELERY_BROKER_URL", ""),
+        backend=os.getenv("CELERY_RESULT_BACKEND", ""),
+    )
+    celery.conf.event_serializer = "pickle"
+    celery.conf.task_serializer = "pickle"
+    celery.conf.result_serializer = "pickle"
+    celery.conf.accept_content = [
+        "application/json",
+        "application/x-python-serialize",
+        "pickle",
+    ]
+    return celery
+
+
+celery = build_celery()

--- a/src/communicator/communicator.py
+++ b/src/communicator/communicator.py
@@ -5,25 +5,12 @@ from typing import List
 from uuid import UUID
 
 import traci
-from celery import Celery, Task
+from celery import Task
 from celery.result import AsyncResult
 from sumolib import checkBinary
 
+from src.communicator.celery import celery
 from src.component import Component
-
-celery = Celery(
-    "proj",
-    broker=os.environ["CELERY_BROKER_URL"],
-    backend=os.environ["CELERY_RESULT_BACKEND"],
-)
-celery.conf.event_serializer = "pickle"
-celery.conf.task_serializer = "pickle"
-celery.conf.result_serializer = "pickle"
-celery.conf.accept_content = [
-    "application/json",
-    "application/x-python-serialize",
-    "pickle",
-]
 
 
 class Communicator:

--- a/tests/communicator/test_communicator.py
+++ b/tests/communicator/test_communicator.py
@@ -1,3 +1,4 @@
+import os
 from time import sleep
 from unittest.mock import patch
 
@@ -55,7 +56,7 @@ def test_component_next_tick_is_called(
 
 
 @patch("src.component.MockComponent.next_tick")
-def test_component_next_tick_is_called_late_add(
+def test_component_next_tick_is_called_add(
     next_tick_mock,
     mock_traci,
 ):  # pylint: disable=unused-argument
@@ -67,3 +68,34 @@ def test_component_next_tick_is_called_late_add(
         sleep(1)
     Communicator.stop(run_id)
     assert next_tick_mock.assert_called
+
+
+@patch("src.communicator.communicator.Communicator._run_with_gui")
+def test_run_with_gui_is_called(
+    run_with_gui_mock,
+):  # pylint: disable=unused-argument
+    """
+    This test verifies that not the run method connected to celery is executed.
+    Instead we should call _run_with_gui.
+    """
+    os.environ["DISABLE_CELERY"] = "True"
+    communicator = Communicator()
+    communicator.run()
+    del os.environ["DISABLE_CELERY"]
+    assert run_with_gui_mock.assert_called
+
+
+@patch("src.communicator.communicator.run_simulation_steps")
+def test_run_simulation_step_is_called_with_gui(
+    run_with_gui_mock,
+    mock_traci,
+):  # pylint: disable=unused-argument
+    """
+    This test verifies that we call run_simulation_steps when running the simulation in gui mode.
+    That run_simulation_steps works correctly is tested in test_component_next_tick_is_called.
+    """
+    os.environ["DISABLE_CELERY"] = "True"
+    communicator = Communicator()
+    communicator.run()
+    del os.environ["DISABLE_CELERY"]
+    assert run_with_gui_mock.assert_called


### PR DESCRIPTION
Fixes #433 

This PR introduces the possibility of simulating with a GUI.
Therefore we have to run the flask app in the terminal instead of a docker container.
You can enable this functionality with `DISABLE_CELERY` environment variable.

## Question

@LucasDerReisende: Do you think this will work with grafana too?
@SaturnHafen: Do you think the traci command works that way every time?

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Breaking changes anounced
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
