### PR TITLE
Feature/388 grafana dashboard coal demand by config

### DIFF
--- a/grafana/local/dashboard_config_based.json
+++ b/grafana/local/dashboard_config_based.json
@@ -18,6 +18,22 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "grafana-simple-json-datasource",
+          "uid": "DATASOURCE_UID"
+        },
+        "enable": true,
+        "iconColor": "red",
+        "name": "Coal Train Spawn Events",
+        "query": "get_coal_spawn_events_by_config_id:${config_id}",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        }
       }
     ]
   },
@@ -130,6 +146,98 @@
         }
       ],
       "title": "Verkehrsleistung",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "DATASOURCE_UID"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "masst"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "DATASOURCE_UID"
+          },
+          "refId": "A",
+          "target": "get_coal_demand_by_config_id:${config_id}",
+          "type": "timeserie"
+        }
+      ],
+      "title": "Kohlebedarf",
       "type": "timeseries"
     },
     {

--- a/src/data_science/data_science.py
+++ b/src/data_science/data_science.py
@@ -223,14 +223,14 @@ class DataScience:
             (block_section_times_df["leave_tick"] >= tick - delta_tick)
             & (block_section_times_df["enter_tick"] <= tick)
         ]
-        source_df["dist"] = self._get_section_length_momentarily_by_tick(
+        dist_series = self._get_section_length_momentarily_by_tick(
             source_df["enter_tick"],
             source_df["leave_tick"],
             source_df["block_section_length"],
             tick,
             delta_tick,
         )
-        return source_df["dist"].sum() * 3600 / delta_tick
+        return np.sum(dist_series) * 3600 / delta_tick
 
     def get_verkehrsleistung_momentarily_time_by_run_id(
         self, run_id: UUID, delta_tick=10
@@ -280,65 +280,7 @@ class DataScience:
         simulation_configuration = (
             Run.select().where(Run.id == run_id).get().simulation_configuration
         )
-        spawner_configurations = list(
-            SpawnerConfigurationXSimulationConfiguration.select().where(
-                SpawnerConfigurationXSimulationConfiguration.simulation_configuration
-                == simulation_configuration
-            )
-        )
-        demand_schedule_strategies_configurations = [
-            [
-                config.schedule_configuration_id
-                for config in SpawnerConfigurationXSchedule.select().where(
-                    SpawnerConfigurationXSchedule.spawner_configuration_id
-                    == spawner_config.spawner_configuration_id
-                )
-            ]
-            for spawner_config in spawner_configurations
-        ]
-        demand_schedule_strategies_configurations = [
-            item
-            for sublist in demand_schedule_strategies_configurations
-            for item in sublist
-        ]
-        demand_schedule_strategies_configurations = list(
-            ScheduleConfiguration.select().where(
-                (ScheduleConfiguration.id << demand_schedule_strategies_configurations)
-                & (ScheduleConfiguration.strategy_type == "DemandScheduleStrategy")
-            )
-        )
-        demand_schedule_strategies = [
-            (DemandScheduleStrategy.from_schedule_configuration(config), config.id)
-            for config in demand_schedule_strategies_configurations
-        ]
-        smard_api = SmardApi()
-        dataframes = []
-        for strategy, config_id in demand_schedule_strategies:
-            data = [
-                entry.value
-                for entry in smard_api.get_data(
-                    strategy.start_datetime,
-                    strategy.start_datetime
-                    + timedelta(seconds=strategy.end_tick - strategy.start_tick),
-                )
-            ]
-            data = map(strategy.compute_coal_consumption, data)
-            smard_df = pd.DataFrame(data, columns=[f"value_{config_id}"])
-
-            smard_df["tick"] = pd.Series(
-                range(strategy.start_tick, strategy.end_tick + 1, 900), dtype="int64"
-            )
-            smard_df.set_index("tick", inplace=True)
-
-            dataframes.append(smard_df)
-
-        result_df = pd.concat(dataframes)
-        result_df.reset_index(inplace=True)
-        result_df["time"] = result_df["tick"] + self.unix_2020
-        result_df["time"] = pd.to_datetime(result_df["time"], unit="s")
-        result_df.set_index("time", inplace=True)
-        del result_df["tick"]
-        return result_df
+        return self.get_coal_demand_by_config_id(simulation_configuration)
 
     def get_spawn_events_by_run_id(self, run_id: UUID) -> pd.DataFrame:
         """Returns the spawn events by a given run id
@@ -490,19 +432,127 @@ class DataScience:
         del verkehrsleistung_df["tick"]
         return verkehrsleistung_df
 
-    def get_coal_demand_by_config_id(self, config_id: UUID) -> pd.DataFrame:
+    def get_coal_demand_by_config_id(
+        self, simulation_configuration: UUID
+    ) -> pd.DataFrame:
         """Returns the coal demand by a given config id
         :param config_id: config id
         :return: coal demand dataframe
         """
-        raise NotImplementedError()
+        spawner_configurations = list(
+            SpawnerConfigurationXSimulationConfiguration.select().where(
+                SpawnerConfigurationXSimulationConfiguration.simulation_configuration
+                == simulation_configuration
+            )
+        )
+        demand_schedule_strategies_configurations = [
+            [
+                config.schedule_configuration_id
+                for config in SpawnerConfigurationXSchedule.select().where(
+                    SpawnerConfigurationXSchedule.spawner_configuration_id
+                    == spawner_config.spawner_configuration_id
+                )
+            ]
+            for spawner_config in spawner_configurations
+        ]
+        demand_schedule_strategies_configurations = [
+            item
+            for sublist in demand_schedule_strategies_configurations
+            for item in sublist
+        ]
+        demand_schedule_strategies_configurations = list(
+            ScheduleConfiguration.select().where(
+                (ScheduleConfiguration.id << demand_schedule_strategies_configurations)
+                & (ScheduleConfiguration.strategy_type == "DemandScheduleStrategy")
+            )
+        )
+        demand_schedule_strategies = [
+            (DemandScheduleStrategy.from_schedule_configuration(config), config.id)
+            for config in demand_schedule_strategies_configurations
+        ]
+        smard_api = SmardApi()
+        dataframes = []
+        for strategy, config_id in demand_schedule_strategies:
+            data = [
+                entry.value
+                for entry in smard_api.get_data(
+                    strategy.start_datetime,
+                    strategy.start_datetime
+                    + timedelta(seconds=strategy.end_tick - strategy.start_tick),
+                )
+            ]
+            data = map(strategy.compute_coal_consumption, data)
+            smard_df = pd.DataFrame(data, columns=[f"value_{config_id}"])
 
-    def get_spawn_events_by_config_id(self, config_id: UUID) -> pd.DataFrame:
+            smard_df["tick"] = pd.Series(
+                range(strategy.start_tick, strategy.end_tick + 1, 900), dtype="int64"
+            )
+            smard_df.set_index("tick", inplace=True)
+
+            dataframes.append(smard_df)
+
+        result_df = pd.concat(dataframes)
+        result_df.reset_index(inplace=True)
+        result_df["time"] = result_df["tick"] + self.unix_2020
+        result_df["time"] = pd.to_datetime(result_df["time"], unit="s")
+        result_df.set_index("time", inplace=True)
+        del result_df["tick"]
+        return result_df
+
+    def get_coal_spawn_events_by_config_id(
+        self, simulation_configuration: UUID
+    ) -> pd.DataFrame:
         """Returns the spawn events by a given config id
         :param config_id: config id
         :return: spawn events dataframe
         """
-        raise NotImplementedError()
+        spawner_configurations = list(
+            SpawnerConfigurationXSimulationConfiguration.select().where(
+                SpawnerConfigurationXSimulationConfiguration.simulation_configuration
+                == simulation_configuration
+            )
+        )
+        demand_schedule_strategies_configurations = [
+            [
+                config.schedule_configuration_id
+                for config in SpawnerConfigurationXSchedule.select().where(
+                    SpawnerConfigurationXSchedule.spawner_configuration_id
+                    == spawner_config.spawner_configuration_id
+                )
+            ]
+            for spawner_config in spawner_configurations
+        ]
+        demand_schedule_strategies_configurations = [
+            item
+            for sublist in demand_schedule_strategies_configurations
+            for item in sublist
+        ]
+        demand_schedule_strategies_configurations = list(
+            ScheduleConfiguration.select().where(
+                (ScheduleConfiguration.id << demand_schedule_strategies_configurations)
+                & (ScheduleConfiguration.strategy_type == "DemandScheduleStrategy")
+            )
+        )
+        demand_schedule_strategies = [
+            (DemandScheduleStrategy.from_schedule_configuration(config), config.id)
+            for config in demand_schedule_strategies_configurations
+        ]
+        dataframes = []
+        for strategy, config_id in demand_schedule_strategies:
+            strategy.calculate_spawn_ticks()
+            spawn_df = pd.DataFrame({"tick": strategy.spawn_ticks})
+            spawn_df["title"] = f"Spawn train from config {config_id}"
+            spawn_df["time"] = spawn_df["tick"] + self.unix_2020
+            spawn_df["time"] = pd.to_datetime(spawn_df["time"], unit="s")
+
+            dataframes.append(spawn_df)
+
+        result_df = pd.concat(dataframes)
+        result_df.reset_index(inplace=True)
+        result_df.set_index("time", inplace=True)
+        del result_df["tick"]
+        del result_df["index"]
+        return result_df
 
     # --- SCALAR
 

--- a/src/data_science/grafana_data_registration.py
+++ b/src/data_science/grafana_data_registration.py
@@ -6,6 +6,7 @@ from grafana_pandas_datasource.registry import data_generators as dg
 from src.data_science.data_science import DataScience
 
 
+# pylint: disable=too-many-public-methods
 class GrafanaDataRegistrator:
     """Class that encapsulates all functions that are used by grafana"""
 
@@ -84,6 +85,22 @@ class GrafanaDataRegistrator:
         :return: dataframe of verkehrsleistung over time"""
         config_id = UUID(param)
         return self.data_science.get_verkehrsleistung_time_by_config_id(config_id)
+
+    def get_coal_demand_by_config_id(self, param, _) -> pd.DataFrame:
+        """Returns the coal demand over time by grafana params
+        :param param: Grafana params
+        :param _: ignored input time range
+        :return: dataframe of coal demand over time by config id"""
+        config_id = UUID(param)
+        return self.data_science.get_coal_demand_by_config_id(config_id)
+
+    def get_coal_spawn_events_by_config_id(self, param, _) -> pd.DataFrame:
+        """Returns the coal train spawn events by grafana params
+        :param param: Grafana params
+        :param _: ignored input time range
+        :return: dataframe of coal train spawn events by config id"""
+        config_id = UUID(param)
+        return self.data_science.get_coal_spawn_events_by_config_id(config_id)
 
     def get_window_by_config_id(self, param, _) -> pd.DataFrame:
         """Returns the window size of the entire network by grafana params
@@ -189,6 +206,8 @@ class GrafanaDataRegistrator:
             "get_verkehrsmenge_by_run_id:${run_id}",
             "get_verkehrsleistung_by_run_id:${run_id}",
             "get_verkehrsleistung_time_by_config_id:${config_id}",
+            "get_coal_demand_by_config_id:${config_id}",
+            "get_coal_spawn_events_by_config_id:${config_id}",
             "get_window_by_config_id:${config_id}",
             "get_window_all_by_config_id:${config_id}",
             "get_verkehrsmenge_by_config_id:${config_id}",
@@ -209,6 +228,10 @@ def define_and_register_data():
     dg.add_annotation_reader(
         "test_get_spawn_events_by_run_id",
         grafana_data_registrator.get_spawn_events_by_run_id,
+    )
+    dg.add_annotation_reader(
+        "get_coal_spawn_events_by_config_id",
+        grafana_data_registrator.get_coal_spawn_events_by_config_id,
     )
     dg.add_metric_reader(
         "get_faults_by_run_id", grafana_data_registrator.get_faults_by_run_id
@@ -236,6 +259,10 @@ def define_and_register_data():
     dg.add_metric_reader(
         "get_verkehrsleistung_time_by_config_id",
         grafana_data_registrator.get_verkehrsleistung_time_by_config_id,
+    )
+    dg.add_metric_reader(
+        "get_coal_demand_by_config_id",
+        grafana_data_registrator.get_coal_demand_by_config_id,
     )
     dg.add_metric_reader(
         "get_window_by_config_id", grafana_data_registrator.get_window_by_config_id

--- a/src/schedule/demand_schedule_strategy.py
+++ b/src/schedule/demand_schedule_strategy.py
@@ -78,7 +78,7 @@ class DemandScheduleStrategy(ScheduleStrategy):
         self.start_datetime = start_datetime
         self.spawn_ticks = []
         self._api = SmardApi()
-        self.calculate_spawn_ticks()
+        self._calculate_spawn_ticks()
 
     def compute_coal_consumption(self, produced_electrical_energy: float) -> float:
         """Computes the coal consumption for the given amount of electrical energy
@@ -112,7 +112,7 @@ class DemandScheduleStrategy(ScheduleStrategy):
         coal_consumption = self.compute_coal_consumption(produced_electrical_power)
         return coal_consumption / self.COAL_PER_TRAIN
 
-    def calculate_spawn_ticks(self):
+    def _calculate_spawn_ticks(self):
         """Calculates the ticks at which trains should spawn."""
         end_datetime = self.start_datetime + timedelta(
             seconds=self.end_tick - self.start_tick

--- a/src/schedule/demand_schedule_strategy.py
+++ b/src/schedule/demand_schedule_strategy.py
@@ -53,7 +53,7 @@ class DemandScheduleStrategy(ScheduleStrategy):
     power_station: str
     scaling_factor: float
     start_datetime: datetime
-    _spawn_ticks: list[int]
+    spawn_ticks: list[int]
     _api: SmardApi
 
     def __init__(
@@ -76,9 +76,9 @@ class DemandScheduleStrategy(ScheduleStrategy):
         self.power_station = power_station
         self.scaling_factor = scaling_factor
         self.start_datetime = start_datetime
-        self._spawn_ticks = []
+        self.spawn_ticks = []
         self._api = SmardApi()
-        self._calculate_spawn_ticks()
+        self.calculate_spawn_ticks()
 
     def compute_coal_consumption(self, produced_electrical_energy: float) -> float:
         """Computes the coal consumption for the given amount of electrical energy
@@ -112,7 +112,7 @@ class DemandScheduleStrategy(ScheduleStrategy):
         coal_consumption = self.compute_coal_consumption(produced_electrical_power)
         return coal_consumption / self.COAL_PER_TRAIN
 
-    def _calculate_spawn_ticks(self):
+    def calculate_spawn_ticks(self):
         """Calculates the ticks at which trains should spawn."""
         end_datetime = self.start_datetime + timedelta(
             seconds=self.end_tick - self.start_tick
@@ -123,10 +123,10 @@ class DemandScheduleStrategy(ScheduleStrategy):
             train_accumulator += self._compute_trains_to_spawn(entry.value)
             tick = int(quarter_hour * self.SECONDS_PER_QUARTER_HOUR + self.start_tick)
             while train_accumulator >= 1.0:
-                self._spawn_ticks.append(tick)
+                self.spawn_ticks.append(tick)
                 train_accumulator -= 1.0
                 tick += 1
 
     def should_spawn(self, tick: int) -> bool:
         """Returns whether a train should spawn at the given tick."""
-        return super().should_spawn(tick) and tick in self._spawn_ticks
+        return super().should_spawn(tick) and tick in self.spawn_ticks

--- a/tests/data_science/test_data_science.py
+++ b/tests/data_science/test_data_science.py
@@ -138,7 +138,7 @@ class TestDataScience:
         demand_train_schedule_configuration: ScheduleConfiguration,
         spawner_configuration: SpawnerConfiguration,
         simulation_configuration: SimulationConfiguration,
-        coal_demand_by_run_id_head_df: pd.DataFrame,
+        coal_demand_by_run_id_head_df,
     ):
         SpawnerConfigurationXSimulationConfiguration.create(
             simulation_configuration=simulation_configuration,
@@ -210,17 +210,48 @@ class TestDataScience:
         self,
         simulation_configuration: SimulationConfiguration,
         data_science: DataScience,
+        demand_strategy: DemandScheduleStrategy,
+        demand_train_schedule_configuration: ScheduleConfiguration,
+        spawner_configuration: SpawnerConfiguration,
+        coal_demand_by_run_id_head_df,
     ):
-        with pytest.raises(NotImplementedError):
-            data_science.get_coal_demand_by_config_id(simulation_configuration)
+        SpawnerConfigurationXSimulationConfiguration.create(
+            simulation_configuration=simulation_configuration,
+            spawner_configuration=spawner_configuration,
+        )
+        SpawnerConfigurationXSchedule.create(
+            spawner_configuration_id=spawner_configuration.id,
+            schedule_configuration_id=demand_train_schedule_configuration.id,
+        )
+        coal_demand_df = data_science.get_coal_demand_by_config_id(
+            simulation_configuration
+        )
+        assert_frame_equal(coal_demand_df.head(10), coal_demand_by_run_id_head_df)
 
-    def test_get_spawn_events_by_config_id(
+    def test_get_coal_spawn_events_by_config_id(
         self,
         simulation_configuration: SimulationConfiguration,
         data_science: DataScience,
+        demand_strategy: DemandScheduleStrategy,
+        demand_train_schedule_configuration: ScheduleConfiguration,
+        spawner_configuration: SpawnerConfiguration,
+        logger: Logger,
+        spawn_coal_events_by_config_id_head_df: pd.DataFrame,
     ):
-        with pytest.raises(NotImplementedError):
-            data_science.get_spawn_events_by_config_id(simulation_configuration)
+        SpawnerConfigurationXSimulationConfiguration.create(
+            simulation_configuration=simulation_configuration,
+            spawner_configuration=spawner_configuration,
+        )
+        SpawnerConfigurationXSchedule.create(
+            spawner_configuration_id=spawner_configuration,
+            schedule_configuration_id=demand_train_schedule_configuration,
+        )
+        spawn_events_df = data_science.get_coal_spawn_events_by_config_id(
+            simulation_configuration
+        )
+        assert_frame_equal(
+            spawn_events_df.head(5), spawn_coal_events_by_config_id_head_df
+        )
 
     def test_get_window_by_config_id(
         self,

--- a/tests/data_science/test_grafana_data_registration.py
+++ b/tests/data_science/test_grafana_data_registration.py
@@ -70,6 +70,8 @@ class TestGrafanaDataRegistration:
             "get_verkehrsmenge_by_run_id:${run_id}",
             "get_verkehrsleistung_by_run_id:${run_id}",
             "get_verkehrsleistung_time_by_config_id:${config_id}",
+            "get_coal_demand_by_config_id:${config_id}",
+            "get_coal_spawn_events_by_config_id:${config_id}",
             "get_window_by_config_id:${config_id}",
             "get_window_all_by_config_id:${config_id}",
             "get_verkehrsmenge_by_config_id:${config_id}",
@@ -142,7 +144,7 @@ class TestGrafanaDataRegistration:
         demand_train_schedule_configuration: ScheduleConfiguration,
         spawner_configuration: SpawnerConfiguration,
         simulation_configuration: SimulationConfiguration,
-        coal_demand_by_run_id_head_df: pd.DataFrame,
+        coal_demand_by_run_id_head_df,
     ):
         SpawnerConfigurationXSimulationConfiguration.create(
             simulation_configuration=simulation_configuration,
@@ -211,6 +213,58 @@ class TestGrafanaDataRegistration:
                 _config_id, None
             ),
             verkehrsleistung_momentarily_time_df,
+        )
+
+    def test_get_coal_demand_by_config_id(
+        self,
+        _config_id: str,
+        logger: Logger,
+        grafana_data_registrator: GrafanaDataRegistrator,
+        demand_strategy: DemandScheduleStrategy,
+        demand_train_schedule_configuration: ScheduleConfiguration,
+        spawner_configuration: SpawnerConfiguration,
+        simulation_configuration: SimulationConfiguration,
+        coal_demand_by_run_id_head_df,
+    ):
+        SpawnerConfigurationXSimulationConfiguration.create(
+            simulation_configuration=simulation_configuration,
+            spawner_configuration=spawner_configuration,
+        )
+        SpawnerConfigurationXSchedule.create(
+            spawner_configuration_id=spawner_configuration.id,
+            schedule_configuration_id=demand_train_schedule_configuration.id,
+        )
+        assert_frame_equal(
+            grafana_data_registrator.get_coal_demand_by_config_id(
+                _config_id, None
+            ).head(10),
+            coal_demand_by_run_id_head_df,
+        )
+
+    def test_get_coal_spawn_events_by_config_id(
+        self,
+        _config_id: str,
+        grafana_data_registrator: GrafanaDataRegistrator,
+        simulation_configuration: SimulationConfiguration,
+        demand_strategy: DemandScheduleStrategy,
+        demand_train_schedule_configuration: ScheduleConfiguration,
+        spawner_configuration: SpawnerConfiguration,
+        logger: Logger,
+        spawn_coal_events_by_config_id_head_df: pd.DataFrame,
+    ):
+        SpawnerConfigurationXSimulationConfiguration.create(
+            simulation_configuration=simulation_configuration,
+            spawner_configuration=spawner_configuration,
+        )
+        SpawnerConfigurationXSchedule.create(
+            spawner_configuration_id=spawner_configuration.id,
+            schedule_configuration_id=demand_train_schedule_configuration.id,
+        )
+        assert_frame_equal(
+            grafana_data_registrator.get_coal_spawn_events_by_config_id(
+                _config_id, None
+            ).head(5),
+            spawn_coal_events_by_config_id_head_df,
         )
 
     def test_get_window_by_config_id(

--- a/tests/fixtures/fixtures_logger.py
+++ b/tests/fixtures/fixtures_logger.py
@@ -351,6 +351,29 @@ def spawn_events_by_run_id_head_df():
 
 
 @pytest.fixture
+def spawn_coal_events_by_config_id_head_df(
+    demand_train_schedule_configuration: ScheduleConfiguration,
+):
+    spawn_events_by_run_id_head_df = pd.DataFrame(
+        {
+            "time": [
+                datetime(2020, 1, 1, 1, 16, 40),
+                datetime(2020, 1, 1, 2, 1, 40),
+                datetime(2020, 1, 1, 3, 1, 40),
+                datetime(2020, 1, 1, 3, 46, 40),
+                datetime(2020, 1, 1, 4, 46, 40),
+            ],
+            f"title": [
+                f"Spawn train from config {demand_train_schedule_configuration.id}"
+                for _ in range(1, 6)
+            ],
+        }
+    )
+    spawn_events_by_run_id_head_df.set_index("time", inplace=True)
+    return spawn_events_by_run_id_head_df
+
+
+@pytest.fixture
 def verkehrsmenge_df():
     return pd.DataFrame({"verkehrsmenge": [164.0]})
 


### PR DESCRIPTION
Fixes #388 

Creates functions to view coal demand of a configuration and coal train spawn events, to view in Grafana Dashboard

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [x] Breaking changes anounced
- [x] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
