### PR TITLE
remove block section length from log leave block section, fix tests

### DIFF
--- a/src/logger/log_collector.py
+++ b/src/logger/log_collector.py
@@ -257,13 +257,13 @@ class LogCollector:
         # pylint: disable=not-an-iterable
         train_leave_df = pd.DataFrame(
             [
-                [e.tick, e.block_section_id, e.block_section_length]
+                [e.tick, e.block_section_id]
                 for e in TrainLeaveBlockSectionLogEntry.select().where(
                     (TrainLeaveBlockSectionLogEntry.run_id == run_id)
                     & (TrainLeaveBlockSectionLogEntry.train_id == train_id)
                 )
             ],
-            columns=["tick", "block_section_id", "block_section_length"],
+            columns=["tick", "block_section_id"],
         )
         train_enter_df = train_enter_df.sort_values("tick")
         train_leave_df = train_leave_df.sort_values("tick")
@@ -279,9 +279,7 @@ class LogCollector:
             block_section_ids = [train_leave_df.iloc[0].block_section_id] + list(
                 block_section_ids
             )
-            block_lengths = [train_leave_df.iloc[0].block_section_length] + list(
-                block_lengths
-            )
+            block_lengths = [None] + list(block_lengths)
         if train_enter_last:
             leave_ticks = list(leave_ticks) + [None]
         block_section_times_df = pd.DataFrame(

--- a/src/logger/log_entry.py
+++ b/src/logger/log_entry.py
@@ -99,7 +99,6 @@ class TrainLeaveBlockSectionLogEntry(LogEntry):
 
     train_id = TextField(null=False)
     block_section_id = TextField(null=False)
-    block_section_length = FloatField(null=False)
 
 
 class InjectFaultLogEntry(LogEntry):

--- a/src/logger/logger.py
+++ b/src/logger/logger.py
@@ -188,7 +188,6 @@ class Logger:
         tick: int,
         train_id: str,
         block_section_id: str,
-        block_section_length: float = 0,
     ) -> Type[None]:
         """
         This function should be called when a train leaves a block section. This should include a
@@ -196,18 +195,15 @@ class Logger:
         :param tick: The current simulation tick
         :param train_id: The id of the train
         :param block_section_id: The id of the block section
-        :param block_section_length: The length of the block section
         :rtype: None
         """
         TrainLeaveBlockSectionLogEntry.create(
             timestamp=datetime.now(),
             tick=tick,
-            message=f"Train with ID {train_id} left block section with ID {block_section_id} "
-            f"with length {block_section_length}",
+            message=f"Train with ID {train_id} left block section with ID {block_section_id}",
             run_id=self.run_id,
             train_id=train_id,
             block_section_id=block_section_id,
-            block_section_length=block_section_length,
         )
 
     def inject_platform_blocked_fault(

--- a/tests/logger/test_log_collector.py
+++ b/tests/logger/test_log_collector.py
@@ -169,7 +169,7 @@ class TestLogCollector:
     def _enter_leave_block_section_3_df(self):
         return pd.DataFrame(
             [
-                [None, 20, "section_1", 10.5],
+                [None, 20, "section_1", None],
                 [30, 40, "section_2", 20.5],
                 [50, 60, "section_3", 30.5],
             ],
@@ -185,7 +185,7 @@ class TestLogCollector:
     def _enter_leave_block_section_4_df(self):
         return pd.DataFrame(
             [
-                [None, 20, "section_1", 10.5],
+                [None, 20, "section_1", None],
                 [30, 40, "section_2", 20.5],
                 [50, None, "section_3", 30.5],
             ],
@@ -207,10 +207,10 @@ class TestLogCollector:
                 [10, 20, "section_1", 10.5, "ice_2"],
                 [30, 40, "section_2", 20.5, "ice_2"],
                 [50, None, "section_3", 30.5, "ice_2"],
-                [None, 20, "section_1", 10.5, "ice_3"],
+                [None, 20, "section_1", None, "ice_3"],
                 [30, 40, "section_2", 20.5, "ice_3"],
                 [50, 60, "section_3", 30.5, "ice_3"],
-                [None, 20, "section_1", 10.5, "ice_4"],
+                [None, 20, "section_1", None, "ice_4"],
                 [30, 40, "section_2", 20.5, "ice_4"],
                 [50, None, "section_3", 30.5, "ice_4"],
             ],
@@ -290,33 +290,33 @@ class TestLogCollector:
     @staticmethod
     def setup_enter_leave_block_section_1(logger):
         logger.train_enter_block_section(10, "ice_1", "section_1", 10.5)
-        logger.train_leave_block_section(20, "ice_1", "section_1", 10.5)
+        logger.train_leave_block_section(20, "ice_1", "section_1")
         logger.train_enter_block_section(30, "ice_1", "section_2", 20.5)
-        logger.train_leave_block_section(40, "ice_1", "section_2", 20.5)
+        logger.train_leave_block_section(40, "ice_1", "section_2")
         logger.train_enter_block_section(50, "ice_1", "section_3", 30.5)
-        logger.train_leave_block_section(60, "ice_1", "section_3", 30.5)
+        logger.train_leave_block_section(60, "ice_1", "section_3")
 
     @staticmethod
     def setup_enter_leave_block_section_2(logger):
         logger.train_enter_block_section(10, "ice_2", "section_1", 10.5)
-        logger.train_leave_block_section(20, "ice_2", "section_1", 10.5)
+        logger.train_leave_block_section(20, "ice_2", "section_1")
         logger.train_enter_block_section(30, "ice_2", "section_2", 20.5)
-        logger.train_leave_block_section(40, "ice_2", "section_2", 20.5)
+        logger.train_leave_block_section(40, "ice_2", "section_2")
         logger.train_enter_block_section(50, "ice_2", "section_3", 30.5)
 
     @staticmethod
     def setup_enter_leave_block_section_3(logger):
-        logger.train_leave_block_section(20, "ice_3", "section_1", 10.5)
+        logger.train_leave_block_section(20, "ice_3", "section_1")
         logger.train_enter_block_section(30, "ice_3", "section_2", 20.5)
-        logger.train_leave_block_section(40, "ice_3", "section_2", 20.5)
+        logger.train_leave_block_section(40, "ice_3", "section_2")
         logger.train_enter_block_section(50, "ice_3", "section_3", 30.5)
-        logger.train_leave_block_section(60, "ice_3", "section_3", 30.5)
+        logger.train_leave_block_section(60, "ice_3", "section_3")
 
     @staticmethod
     def setup_enter_leave_block_section_4(logger):
-        logger.train_leave_block_section(20, "ice_4", "section_1", 10.5)
+        logger.train_leave_block_section(20, "ice_4", "section_1")
         logger.train_enter_block_section(30, "ice_4", "section_2", 20.5)
-        logger.train_leave_block_section(40, "ice_4", "section_2", 20.5)
+        logger.train_leave_block_section(40, "ice_4", "section_2")
         logger.train_enter_block_section(50, "ice_4", "section_3", 30.5)
 
     @staticmethod

--- a/tests/logger/test_log_entry.py
+++ b/tests/logger/test_log_entry.py
@@ -579,7 +579,6 @@ class TestLogEntry:
             run,
             train_id,
             block_section_id,
-            block_section_length,
         ):
             """TrainLeaveBlockSectionLogEntry as dict with all fields set."""
             return {
@@ -589,7 +588,6 @@ class TestLogEntry:
                 "run_id": run.id,
                 "train_id": train_id,
                 "block_section_id": block_section_id,
-                "block_section_length": block_section_length,
             }
 
         @pytest.fixture
@@ -601,7 +599,6 @@ class TestLogEntry:
             run,
             train_id,
             block_section_id,
-            block_section_length,
         ):
             """TrainLeaveBlockSectionLogEntry as dict with all fields set."""
             return {
@@ -611,7 +608,6 @@ class TestLogEntry:
                 "run_id": str(run.id),
                 "train_id": train_id,
                 "block_section_id": block_section_id,
-                "block_section_length": block_section_length,
             }
 
         @pytest.fixture

--- a/tests/logger/test_logger.py
+++ b/tests/logger/test_logger.py
@@ -210,7 +210,6 @@ class TestLogger:
             tick=tick,
             train_id=train_id,
             block_section_id=block_section_id,
-            block_section_length=block_section_length,
         )
         log_entry = (
             TrainLeaveBlockSectionLogEntry.select()
@@ -225,13 +224,11 @@ class TestLogger:
         assert log_entry.tick == tick
         assert (
             log_entry.message
-            == f"Train with ID {train_id} left block section with ID {block_section_id} with "
-            f"length {block_section_length}"
+            == f"Train with ID {train_id} left block section with ID {block_section_id}"
         )
         assert log_entry.run_id.id == run.id
         assert log_entry.train_id == train_id
         assert log_entry.block_section_id == block_section_id
-        assert log_entry.block_section_length == block_section_length
 
     @freeze_time()
     def test_inject_platform_blocked_fault(


### PR DESCRIPTION
Fixes #432 

Removes block section length as attribute from train leave block section log entries, and corresponding log functions

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [x] Docs (code, wiki & diagrams) updated
- [x] Breaking changes anounced
- [x] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [x] Dev-branch has been merged into local branch to resolve conflicts
- [x] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
