### PR TITLE
feat: added new test commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,11 +102,30 @@ build-backend = "poetry.core.masonry.api"
 
     [tool.poe.tasks.test]
     help = "Run DB and test with pytest"
-    sequence = ["test-deps", "sleep", "db-test recreate", "test-pytest"]
+    sequence = ["test-deps", "test-pytest"]
+    envfile = [".env.shared", ".env.test"]
+
+    [tool.poe.tasks.test-lf]
+    help = "Run DB and test with pytest (only tests that failed last time)"
+    sequence = ["test-deps", "test-pytest --lf"]
+    envfile = [".env.shared", ".env.test"]
+
+    [tool.poe.tasks.test-ff]
+    help = "Run DB and test with pytest (tests that failed last time first)"
+    sequence = ["test-deps", "test-pytest --ff"]
+    envfile = [".env.shared", ".env.test"]
+
+    [tool.poe.tasks.test-nf]
+    help = "Run DB and test with pytest (new tests first)"
+    sequence = ["test-deps", "test-pytest --nf"]
     envfile = [".env.shared", ".env.test"]
 
     [tool.poe.tasks.test-deps]
     help = "Initializes needed components for tests"
+    sequence = ["test-docker-deps", "sleep", "db-test recreate"]
+
+    [tool.poe.tasks.test-docker-deps]
+    help = "Initializes needed docker containers for tests"
     cmd = "docker compose up -d grafana-test celery-worker postgresql-test"
 
     [tool.poe.tasks.test-pytest]


### PR DESCRIPTION
Fixes #467

We have 3 new poe test commands:

`poe test-nf`: Run the new tests first (**n**ew **f**irst)
`poe test-ff`: Run previously failed tests first (**f**ailed **f**irst)
`poe test-lf`: Only run previously failed tests (**l**ast **f**ailed)

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] ~~Added classes that inherit from `BaseModel` to `src.constants.tables`~~
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
