### PR TITLE
Add functionality to `/component/fault-injection/schedule-blocked-fault/{id}`

### DIFF
--- a/src/implementor/component.py
+++ b/src/implementor/component.py
@@ -26,7 +26,7 @@ from src.implementor.models import SimulationConfiguration
 
 def get_all_schedule_blocked_fault_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the schedule-blocked-faul configuration of a single simulation
         :param token: Token object of the current user
@@ -73,35 +73,51 @@ def create_schedule_blocked_fault_configuration(body, token):
 
 def get_schedule_blocked_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
-        options["id"]
+    :param options: A dictionary containing all the parameters for the Operations
+        options["identifier"]
     :param token: Token object of the current user
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
-
-    return json.dumps("<map>"), 501  # 200
+    identifier = options["identifier"]
+    configs = ScheduleBlockedFaultConfiguration.select().where(
+        ScheduleBlockedFaultConfiguration.id == identifier
+    )
+    if not configs.exists():
+        return "Id not found", 404
+    config = configs.get()
+    return config.to_dict(), 200
 
 
 def delete_schedule_blocked_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
-        options["id"]
+    :param options: A dictionary containing all the parameters for the Operations
+        options["identifier"]
     :param token: Token object of the current user
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
+    identifier = options["identifier"]
+    configs = ScheduleBlockedFaultConfiguration.select().where(
+        ScheduleBlockedFaultConfiguration.id == identifier
+    )
+    if not configs.exists():
+        return "Id not found", 404
+    config = configs.get()
 
-    return "", 501  # 204
+    if config.simulation_configuration_references.exists():
+        return (
+            "Platform blocked fault configuration is referenced by a simulation configuration",
+            400,
+        )
+
+    config.delete_instance()
+    return "Deleted platform-blocked-fault configuration", 204
 
 
 def get_all_track_blocked_fault_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the track-blocked-fault configuration of a single simulation
         :param token: Token object of the current user
@@ -150,7 +166,7 @@ def create_track_blocked_fault_configuration(body, token):
 
 def get_track_blocked_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -164,7 +180,7 @@ def get_track_blocked_fault_configuration(options, token):
 
 def delete_track_blocked_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -178,7 +194,7 @@ def delete_track_blocked_fault_configuration(options, token):
 
 def get_all_track_speed_limit_fault_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the track-speed-limit-fault configuration of a single simulation
         :param token: Token object of the current user
@@ -228,7 +244,7 @@ def create_track_speed_limit_fault_configuration(body, token):
 
 def get_track_speed_limit_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -242,7 +258,7 @@ def get_track_speed_limit_fault_configuration(options, token):
 
 def delete_track_speed_limit_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -256,7 +272,7 @@ def delete_track_speed_limit_fault_configuration(options, token):
 
 def get_all_train_prio_fault_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the train-prio-fault configuration of a single simulation
         :param token: Token object of the current user
@@ -300,7 +316,7 @@ def create_train_prio_fault_configuration(body, token):
 
 def get_train_prio_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -314,7 +330,7 @@ def get_train_prio_fault_configuration(options, token):
 
 def delete_train_prio_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -328,7 +344,7 @@ def delete_train_prio_fault_configuration(options, token):
 
 def get_all_train_speed_fault_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the train-speed-fault configuration of a single simulation
         :param token: Token object of the current user
@@ -375,7 +391,7 @@ def create_train_speed_fault_configuration(body, token):
 
 def get_train_speed_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -389,7 +405,7 @@ def get_train_speed_fault_configuration(options, token):
 
 def delete_train_speed_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -403,7 +419,7 @@ def delete_train_speed_fault_configuration(options, token):
 
 def get_all_platform_blocked_fault_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the train-speed-fault configuration of a single simulation
         :param token: Token object of the current user
@@ -452,14 +468,12 @@ def create_platform_blocked_fault_configuration(body, token):
 
 def get_platform_blocked_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["identifier"]
     :param token: Token object of the current user
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
     identifier = options["identifier"]
     configs = PlatformBlockedFaultConfiguration.select().where(
         PlatformBlockedFaultConfiguration.id == identifier
@@ -472,14 +486,11 @@ def get_platform_blocked_fault_configuration(options, token):
 
 def delete_platform_blocked_fault_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["identifier"]
     :param token: Token object of the current user
 
     """
-
-    # Implement your business logic here
-    # All the parameters are present in the options argument
 
     identifier = options["identifier"]
     configs = PlatformBlockedFaultConfiguration.select().where(
@@ -501,7 +512,7 @@ def delete_platform_blocked_fault_configuration(options, token):
 
 def get_all_interlocking_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the interlocking configuration of a single simulation
         :param token: Token object of the current user
@@ -536,7 +547,7 @@ def create_interlocking_configuration(body, token):
 
 def get_interlocking_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -550,7 +561,7 @@ def get_interlocking_configuration(options, token):
 
 def delete_interlocking_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -564,7 +575,7 @@ def delete_interlocking_configuration(options, token):
 
 def get_all_spawner_configuration_ids(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["simulationId"]: Specify id of simulation
             if you only want to get the spawner configuration of a single simulation
         :param token: Token object of the current user
@@ -599,7 +610,7 @@ def create_spawner_configuration(body, token):
 
 def get_spawner_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 
@@ -613,7 +624,7 @@ def get_spawner_configuration(options, token):
 
 def delete_spawner_configuration(options, token):
     """
-    :param options: A dictionary containing all the paramters for the Operations
+    :param options: A dictionary containing all the parameters for the Operations
         options["id"]
     :param token: Token object of the current user
 

--- a/src/implementor/component.py
+++ b/src/implementor/component.py
@@ -107,12 +107,12 @@ def delete_schedule_blocked_fault_configuration(options, token):
 
     if config.simulation_configuration_references.exists():
         return (
-            "Platform blocked fault configuration is referenced by a simulation configuration",
+            "Schedule blocked fault configuration is referenced by a simulation configuration",
             400,
         )
 
     config.delete_instance()
-    return "Deleted platform-blocked-fault configuration", 204
+    return "Deleted schedule-blocked-fault configuration", 204
 
 
 def get_all_track_blocked_fault_configuration_ids(options, token):

--- a/tests/api/test_api_schedule_blocked_fault.py
+++ b/tests/api/test_api_schedule_blocked_fault.py
@@ -55,7 +55,7 @@ class TestApiScheduleBlockedFault:
             f"/component/fault-injection/schedule-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 501
+        assert response.status_code == 404
 
     def test_delete(self, client, clear_token):
         object_id = uuid.uuid4()
@@ -63,4 +63,4 @@ class TestApiScheduleBlockedFault:
             f"/component/fault-injection/schedule-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 501
+        assert response.status_code == 404

--- a/tests/api/test_decorator.py
+++ b/tests/api/test_decorator.py
@@ -24,7 +24,7 @@ TOKEN_HEADER = "bp2022-ap1-api-key"
         ("/component/spawner/00000000-0000-0000-0000-000000000000", 501),
         (
             "/component/fault-injection/schedule-blocked-fault/00000000-0000-0000-0000-000000000000",
-            501,
+            404,
         ),
         (
             "/component/fault-injection/platform-blocked-fault/00000000-0000-0000-0000-000000000000",

--- a/tests/implementor/test_impl_schedule_blocked_fault.py
+++ b/tests/implementor/test_impl_schedule_blocked_fault.py
@@ -1,5 +1,5 @@
-from uuid import UUID
 import uuid
+from uuid import UUID
 
 from src import implementor as impl
 from src.fault_injector.fault_configurations.schedule_blocked_fault_configuration import (

--- a/tests/implementor/test_impl_schedule_blocked_fault.py
+++ b/tests/implementor/test_impl_schedule_blocked_fault.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+import uuid
 
 from src import implementor as impl
 from src.fault_injector.fault_configurations.schedule_blocked_fault_configuration import (
@@ -72,3 +73,82 @@ class TestScheduleBlockedFaultConfiguration:
             assert compare(
                 getattr(config, key), schedule_blocked_fault_configuration_data[key]
             )
+
+    def test_get_schedule_blocked_fault_configuration(
+        self, token, schedule_blocked_fault_configuration_data
+    ):
+        config = ScheduleBlockedFaultConfiguration.create(
+            **schedule_blocked_fault_configuration_data
+        )
+
+        response = impl.component.get_schedule_blocked_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 200
+        assert str(config.id) == result["id"]
+        assert str(config.updated_at) == result["updated_at"]
+        assert str(config.created_at) == result["created_at"]
+        assert config.start_tick == result["start_tick"]
+        assert config.end_tick == result["end_tick"]
+        assert config.inject_probability == result["inject_probability"]
+        assert config.resolve_probability == result["resolve_probability"]
+        assert str(config.description) == result["description"]
+        assert str(config.strategy) == result["strategy"]
+        assert str(config.affected_element_id) == result["affected_element_id"]
+
+    def test_delete_schedule_blocked_fault_configuration(
+        self,
+        token,
+        schedule_blocked_fault_configuration_data,
+    ):
+        config = ScheduleBlockedFaultConfiguration.create(
+            **schedule_blocked_fault_configuration_data
+        )
+        response = impl.component.delete_schedule_blocked_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 204
+        assert result == "Deleted schedule-blocked-fault configuration"
+        assert (
+            not ScheduleBlockedFaultConfiguration.select()
+            .where(ScheduleBlockedFaultConfiguration.id == config.id)
+            .exists()
+        )
+
+    def test_delete_schedule_blocked_fault_configuration_not_found(
+        self,
+        token,
+        schedule_blocked_fault_configuration_data,
+    ):
+        object_id = uuid.uuid4()
+        response = impl.component.delete_schedule_blocked_fault_configuration(
+            {"identifier": object_id}, token
+        )
+        (result, status) = response
+        assert status == 404
+        assert result == "Id not found"
+
+    def test_delete_schedule_blocked_fault_configuration_in_use(
+        self,
+        token,
+        schedule_blocked_fault_configuration_data,
+        empty_simulation_configuration,
+    ):
+        config = ScheduleBlockedFaultConfiguration.create(
+            **schedule_blocked_fault_configuration_data
+        )
+        ScheduleBlockedFaultConfigurationXSimulationConfiguration.create(
+            simulation_configuration=empty_simulation_configuration,
+            schedule_blocked_fault_configuration=config,
+        )
+        response = impl.component.delete_schedule_blocked_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 400
+        assert (
+            result
+            == "Schedule blocked fault configuration is referenced by a simulation configuration"
+        )


### PR DESCRIPTION
Fixes #204 

This PR adds functionality to the route component/fault-injection/schedule-blocked-fault/:id.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
