### PR TITLE
Add functionality to `/component/fault-injection/track-blocked-fault/{id}` path

### DIFF
--- a/src/implementor/component.py
+++ b/src/implementor/component.py
@@ -151,29 +151,45 @@ def create_track_blocked_fault_configuration(body, token):
 def get_track_blocked_fault_configuration(options, token):
     """
     :param options: A dictionary containing all the paramters for the Operations
-        options["id"]
+        options["identifier"]
     :param token: Token object of the current user
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
-
-    return json.dumps("<map>"), 501  # 200
+    identifier = options["identifier"]
+    configs = TrackBlockedFaultConfiguration.select().where(
+        TrackBlockedFaultConfiguration.id == identifier
+    )
+    if not configs.exists():
+        return "Id not found", 404
+    config = configs.get()
+    return config.to_dict(), 200
 
 
 def delete_track_blocked_fault_configuration(options, token):
     """
     :param options: A dictionary containing all the paramters for the Operations
-        options["id"]
+        options["identifier"]
     :param token: Token object of the current user
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
+    identifier = options["identifier"]
+    configs = TrackBlockedFaultConfiguration.select().where(
+        TrackBlockedFaultConfiguration.id == identifier
+    )
+    if not configs.exists():
+        return "Id not found", 404
+    config = configs.get()
 
-    return "", 501  # 204
+    if config.simulation_configuration_references.exists():
+        return (
+            "Track blocked fault configuration is referenced by a simulation configuration",
+            400,
+        )
+
+    config.delete_instance()
+    return "Deleted track-blocked-fault configuration", 204
 
 
 def get_all_track_speed_limit_fault_configuration_ids(options, token):

--- a/tests/api/test_api_track_blocked_fault.py
+++ b/tests/api/test_api_track_blocked_fault.py
@@ -55,7 +55,7 @@ class TestApiTrackBlockedFault:
             f"/component/fault-injection/track-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 501
+        assert response.status_code == 404
 
     def test_delete(self, client, clear_token):
         object_id = uuid.uuid4()
@@ -63,4 +63,4 @@ class TestApiTrackBlockedFault:
             f"/component/fault-injection/track-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 501
+        assert response.status_code == 404

--- a/tests/api/test_decorator.py
+++ b/tests/api/test_decorator.py
@@ -32,7 +32,7 @@ TOKEN_HEADER = "bp2022-ap1-api-key"
         ),
         (
             "/component/fault-injection/track-blocked-fault/00000000-0000-0000-0000-000000000000",
-            501,
+            404,
         ),
         (
             "/component/fault-injection/train-prio-fault/00000000-0000-0000-0000-000000000000",

--- a/tests/implementor/test_impl_track_blocked_fault.py
+++ b/tests/implementor/test_impl_track_blocked_fault.py
@@ -1,3 +1,5 @@
+import uuid
+
 from src import implementor as impl
 from src.fault_injector.fault_configurations.track_blocked_fault_configuration import (
     TrackBlockedFaultConfiguration,
@@ -62,3 +64,82 @@ class TestTrackBlockedFaultConfiguration:
         config = configs.get()
         for key in track_blocked_fault_configuration_data:
             assert getattr(config, key) == track_blocked_fault_configuration_data[key]
+
+    def test_get_track_blocked_fault_configuration(
+        self, token, track_blocked_fault_configuration_data
+    ):
+        config = TrackBlockedFaultConfiguration.create(
+            **track_blocked_fault_configuration_data
+        )
+
+        response = impl.component.get_track_blocked_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 200
+        assert str(config.id) == result["id"]
+        assert str(config.updated_at) == result["updated_at"]
+        assert str(config.created_at) == result["created_at"]
+        assert config.start_tick == result["start_tick"]
+        assert config.end_tick == result["end_tick"]
+        assert config.inject_probability == result["inject_probability"]
+        assert config.resolve_probability == result["resolve_probability"]
+        assert str(config.description) == result["description"]
+        assert str(config.strategy) == result["strategy"]
+        assert str(config.affected_element_id) == result["affected_element_id"]
+
+    def test_delete_track_blocked_fault_configuration(
+        self,
+        token,
+        track_blocked_fault_configuration_data,
+    ):
+        config = TrackBlockedFaultConfiguration.create(
+            **track_blocked_fault_configuration_data
+        )
+        response = impl.component.delete_track_blocked_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 204
+        assert result == "Deleted track-blocked-fault configuration"
+        assert (
+            not TrackBlockedFaultConfiguration.select()
+            .where(TrackBlockedFaultConfiguration.id == config.id)
+            .exists()
+        )
+
+    def test_delete_track_blocked_fault_configuration_not_found(
+        self,
+        token,
+        track_blocked_fault_configuration_data,
+    ):
+        object_id = uuid.uuid4()
+        response = impl.component.delete_track_blocked_fault_configuration(
+            {"identifier": object_id}, token
+        )
+        (result, status) = response
+        assert status == 404
+        assert result == "Id not found"
+
+    def test_delete_track_blocked_fault_configuration_in_use(
+        self,
+        token,
+        track_blocked_fault_configuration_data,
+        empty_simulation_configuration,
+    ):
+        config = TrackBlockedFaultConfiguration.create(
+            **track_blocked_fault_configuration_data
+        )
+        TrackBlockedFaultConfigurationXSimulationConfiguration.create(
+            simulation_configuration=empty_simulation_configuration,
+            track_blocked_fault_configuration=config,
+        )
+        response = impl.component.delete_track_blocked_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 400
+        assert (
+            result
+            == "Track blocked fault configuration is referenced by a simulation configuration"
+        )


### PR DESCRIPTION
Fixes #205

This PR adds functionality to the route component/fault-injection/track-blocked-fault/:id.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
