### PR TITLE
Add functionality to /component/fault-injection/track-speed-limit-fault/{id} path

### DIFF
--- a/src/implementor/component.py
+++ b/src/implementor/component.py
@@ -229,29 +229,45 @@ def create_track_speed_limit_fault_configuration(body, token):
 def get_track_speed_limit_fault_configuration(options, token):
     """
     :param options: A dictionary containing all the paramters for the Operations
-        options["id"]
+        options["identifier"]
     :param token: Token object of the current user
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
-
-    return json.dumps("<map>"), 501  # 200
+    identifier = options["identifier"]
+    configs = TrackSpeedLimitFaultConfiguration.select().where(
+        TrackSpeedLimitFaultConfiguration.id == identifier
+    )
+    if not configs.exists():
+        return "Id not found", 404
+    config = configs.get()
+    return config.to_dict(), 200
 
 
 def delete_track_speed_limit_fault_configuration(options, token):
     """
     :param options: A dictionary containing all the paramters for the Operations
-        options["id"]
+        options["identifier"]
     :param token: Token object of the current user
 
     """
 
-    # Implement your business logic here
-    # All the parameters are present in the options argument
+    identifier = options["identifier"]
+    configs = TrackSpeedLimitFaultConfiguration.select().where(
+        TrackSpeedLimitFaultConfiguration.id == identifier
+    )
+    if not configs.exists():
+        return "Id not found", 404
+    config = configs.get()
 
-    return "", 501  # 204
+    if config.simulation_configuration_references.exists():
+        return (
+            "Track speed limit fault configuration is referenced by a simulation configuration",
+            400,
+        )
+
+    config.delete_instance()
+    return "Deleted track-speed-limit-fault configuration", 204
 
 
 def get_all_train_prio_fault_configuration_ids(options, token):

--- a/tests/api/test_api_track_speed_limit_fault.py
+++ b/tests/api/test_api_track_speed_limit_fault.py
@@ -61,7 +61,7 @@ class TestApiTrackSpeedLimitFault:
             f"/component/fault-injection/track-speed-limit-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 501
+        assert response.status_code == 404
 
     def test_delete(self, client, clear_token):
         object_id = uuid.uuid4()
@@ -69,4 +69,4 @@ class TestApiTrackSpeedLimitFault:
             f"/component/fault-injection/track-speed-limit-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 501
+        assert response.status_code == 404

--- a/tests/api/test_decorator.py
+++ b/tests/api/test_decorator.py
@@ -44,7 +44,7 @@ TOKEN_HEADER = "bp2022-ap1-api-key"
         ),
         (
             "/component/fault-injection/track-speed-limit-fault/00000000-0000-0000-0000-000000000000",
-            501,
+            404,
         ),
     ],
 )

--- a/tests/implementor/test_impl_track_speed_limit_fault.py
+++ b/tests/implementor/test_impl_track_speed_limit_fault.py
@@ -64,3 +64,83 @@ class TestTrackSpeedLimitFaultConfiguration:
             assert (
                 getattr(config, key) == track_speed_limit_fault_configuration_data[key]
             )
+
+
+    def test_get_track_speed_limit_fault_configuration(
+        self, token, track_speed_limit_fault_configuration_data
+    ):
+        config = TrackSpeedLimitFaultConfiguration.create(
+            **track_speed_limit_fault_configuration_data
+        )
+
+        response = impl.component.get_track_speed_limit_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 200
+        assert str(config.id) == result["id"]
+        assert str(config.updated_at) == result["updated_at"]
+        assert str(config.created_at) == result["created_at"]
+        assert config.start_tick == result["start_tick"]
+        assert config.end_tick == result["end_tick"]
+        assert config.inject_probability == result["inject_probability"]
+        assert config.resolve_probability == result["resolve_probability"]
+        assert str(config.description) == result["description"]
+        assert str(config.strategy) == result["strategy"]
+        assert str(config.affected_element_id) == result["affected_element_id"]
+
+    def test_delete_track_speed_limit_fault_configuration(
+        self,
+        token,
+        track_speed_limit_fault_configuration_data,
+    ):
+        config = TrackSpeedLimitFaultConfiguration.create(
+            **track_speed_limit_fault_configuration_data
+        )
+        response = impl.component.delete_track_speed_limit_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 204
+        assert result == "Deleted track-speed-limit-fault configuration"
+        assert (
+            not TrackSpeedLimitFaultConfiguration.select()
+            .where(TrackSpeedLimitFaultConfiguration.id == config.id)
+            .exists()
+        )
+
+    def test_delete_track_speed_limit_fault_configuration_not_found(
+        self,
+        token,
+        track_speed_limit_fault_configuration_data,
+    ):
+        object_id = uuid.uuid4()
+        response = impl.component.delete_track_speed_limit_fault_configuration(
+            {"identifier": object_id}, token
+        )
+        (result, status) = response
+        assert status == 404
+        assert result == "Id not found"
+
+    def test_delete_track_speed_limit_fault_configuration_in_use(
+        self,
+        token,
+        track_speed_limit_fault_configuration_data,
+        empty_simulation_configuration,
+    ):
+        config = TrackSpeedLimitFaultConfiguration.create(
+            **track_speed_limit_fault_configuration_data
+        )
+        TrackSpeedLimitFaultConfigurationXSimulationConfiguration.create(
+            simulation_configuration=empty_simulation_configuration,
+            track_speed_limit_fault_configuration=config,
+        )
+        response = impl.component.delete_track_speed_limit_fault_configuration(
+            {"identifier": str(config.id)}, token
+        )
+        (result, status) = response
+        assert status == 400
+        assert (
+            result
+            == "Track speed limit fault configuration is referenced by a simulation configuration"
+        )

--- a/tests/implementor/test_impl_track_speed_limit_fault.py
+++ b/tests/implementor/test_impl_track_speed_limit_fault.py
@@ -1,3 +1,5 @@
+import uuid
+
 from src import implementor as impl
 from src.fault_injector.fault_configurations.track_speed_limit_fault_configuration import (
     TrackSpeedLimitFaultConfiguration,
@@ -64,7 +66,6 @@ class TestTrackSpeedLimitFaultConfiguration:
             assert (
                 getattr(config, key) == track_speed_limit_fault_configuration_data[key]
             )
-
 
     def test_get_track_speed_limit_fault_configuration(
         self, token, track_speed_limit_fault_configuration_data


### PR DESCRIPTION
Fixes #206 

This PR adds functionality to the route component/fault-injection/track-speed-limit-fault/:id.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
