### PR TITLE
Feature/512 init files for tests

### DIFF
--- a/tests/api/test_decorator.py
+++ b/tests/api/test_decorator.py
@@ -18,30 +18,37 @@ TOKEN_HEADER = "bp2022-ap1-api-key"
         ("/component/fault-injection/track-speed-limit-fault", 200),
         ("/run/00000000-0000-0000-0000-000000000000", 404),
         ("/simulation/00000000-0000-0000-0000-000000000000", 404),
-        # ("/component/interlocking/00000000-0000-0000-0000-000000000000", 501), # INTERLOCKING CONFIGURATION IS TEMPORARILY DISABLED
+        # INTERLOCKING CONFIGURATION IS TEMPORARILY DISABLED
+        # ("/component/interlocking/00000000-0000-0000-0000-000000000000", 501),
         ("/component/spawner/00000000-0000-0000-0000-000000000000", 404),
         (
-            "/component/fault-injection/schedule-blocked-fault/00000000-0000-0000-0000-000000000000",
+            "/component/fault-injection/schedule-blocked-fault"
+            "/00000000-0000-0000-0000-000000000000",
             404,
         ),
         (
-            "/component/fault-injection/platform-blocked-fault/00000000-0000-0000-0000-000000000000",
+            "/component/fault-injection/platform-blocked-fault"
+            "/00000000-0000-0000-0000-000000000000",
             404,
         ),
         (
-            "/component/fault-injection/track-blocked-fault/00000000-0000-0000-0000-000000000000",
+            "/component/fault-injection/track-blocked-fault"
+            "/00000000-0000-0000-0000-000000000000",
             404,
         ),
         (
-            "/component/fault-injection/train-prio-fault/00000000-0000-0000-0000-000000000000",
+            "/component/fault-injection/train-prio-fault"
+            "/00000000-0000-0000-0000-000000000000",
             404,
         ),
         (
-            "/component/fault-injection/train-speed-fault/00000000-0000-0000-0000-000000000000",
+            "/component/fault-injection/train-speed-fault"
+            "/00000000-0000-0000-0000-000000000000",
             404,
         ),
         (
-            "/component/fault-injection/track-speed-limit-fault/00000000-0000-0000-0000-000000000000",
+            "/component/fault-injection/track-speed-limit-fault"
+            "/00000000-0000-0000-0000-000000000000",
             404,
         ),
     ],

--- a/tests/db/test_db.py
+++ b/tests/db/test_db.py
@@ -1,10 +1,8 @@
 from datetime import datetime
-from uuid import UUID
 
-import marshmallow as marsh
 from peewee import IntegerField
 
-from src.base_model import BaseModel, SerializableBaseModel, db
+from src.base_model import SerializableBaseModel, db
 from tests.decorators import recreate_db_setup
 
 

--- a/tests/event_bus/test_event_bus.py
+++ b/tests/event_bus/test_event_bus.py
@@ -5,8 +5,6 @@ import pytest
 from src.event_bus.event import Event, EventType
 from src.event_bus.event_bus import EventBus
 
-# pylint disable=attribute-defined-outside-init
-
 
 class TestEventBus:
     """Tests for the EventBus"""
@@ -34,6 +32,8 @@ class TestEventBus:
     def train_id(self) -> str:
         return "cool_train_id"
 
+    callback_called: bool = False
+
     def test_register_callback(
         self,
         event_bus: EventBus,
@@ -58,8 +58,6 @@ class TestEventBus:
     def test_event(
         self, event_bus: EventBus, event_type: EventType, tick: int, train_id: str
     ):
-        self.callback_called = False
-
         def callback(event: Event):
             self.callback_called = True
             assert event.event_type == event_type

--- a/tests/event_bus/test_event_bus.py
+++ b/tests/event_bus/test_event_bus.py
@@ -5,6 +5,8 @@ import pytest
 from src.event_bus.event import Event, EventType
 from src.event_bus.event_bus import EventBus
 
+# pylint disable=attribute-defined-outside-init
+
 
 class TestEventBus:
     """Tests for the EventBus"""
@@ -19,7 +21,7 @@ class TestEventBus:
 
     @pytest.fixture
     def callback(self) -> Callable[[Event], None]:
-        def _callback(event: Event):
+        def _callback(_: Event):
             pass
 
         return _callback

--- a/tests/fault_injector/conftest.py
+++ b/tests/fault_injector/conftest.py
@@ -75,11 +75,6 @@ def track(edge, edge_re):
 
 
 @pytest.fixture
-def track(edge, edge_re):
-    return Track(edge, edge_re)
-
-
-@pytest.fixture
 def combine_track_and_wrapper(
     track: Track, simulation_object_updater: SimulationObjectUpdatingComponent
 ):

--- a/tests/fault_injector/test_affected_element_does_not_exist.py
+++ b/tests/fault_injector/test_affected_element_does_not_exist.py
@@ -102,7 +102,9 @@ from tests.decorators import recreate_db_setup
     ],
 )
 class TestAffectedElementDoesNotExist:
-    """Test cases where the requested element for injecting a fault does not exist (in the simulation)"""
+    """Test cases where the requested element for injecting a
+    fault does not exist (in the simulation)
+    """
 
     @recreate_db_setup
     def setup_method(self):
@@ -138,7 +140,9 @@ class TestAffectedElementDoesNotExist:
 
 
 class TestAffectedElementDoesNotExistScheduleBlockedFault:
-    """Tests cases where the requested element for injecting a schedule blocked fault does not exist (in the simulation)"""
+    """Tests cases where the requested element for injecting a schedule "
+    "blocked fault does not exist (in the simulation)
+    """
 
     @recreate_db_setup
     def setup_method(self):

--- a/tests/fault_injector/test_fault.py
+++ b/tests/fault_injector/test_fault.py
@@ -1,23 +1,23 @@
-from uuid import UUID
-
 import pytest
 
 from src.fault_injector.fault_configurations.fault_configuration import (
     FaultConfiguration,
 )
 from src.fault_injector.fault_types.fault import Fault
-from src.interlocking_component.route_controller import IInterlockingDisruptor
-from src.logger.logger import Logger
-from src.wrapper.simulation_object_updating_component import (
-    SimulationObjectUpdatingComponent,
-)
 
 
 class TestFault:
+    """ Test fault
+    """
+
     class MockConfiguration(FaultConfiguration):
+        """ Mock configuration
+        """
         strategy: str = "regular"
 
     class MockSpecialFault(Fault):
+        """ Mock fault
+        """
         tick_injected: int = 0
         tick_resolved: int = 0
 

--- a/tests/fault_injector/test_fault.py
+++ b/tests/fault_injector/test_fault.py
@@ -7,17 +7,16 @@ from src.fault_injector.fault_types.fault import Fault
 
 
 class TestFault:
-    """ Test fault
-    """
+    """Test fault"""
 
     class MockConfiguration(FaultConfiguration):
-        """ Mock configuration
-        """
+        """Mock configuration"""
+
         strategy: str = "regular"
 
     class MockSpecialFault(Fault):
-        """ Mock fault
-        """
+        """Mock fault"""
+
         tick_injected: int = 0
         tick_resolved: int = 0
 

--- a/tests/fault_injector/test_fault_injector.py
+++ b/tests/fault_injector/test_fault_injector.py
@@ -9,8 +9,8 @@ class TestFaultInjector:
     """tests the method of the fault injector component"""
 
     class MockFault:
-        """ A mock fault class to test the fault injector component
-        """
+        """A mock fault class to test the fault injector component"""
+
         received_ticks: int = 0
         last_tick: int
 

--- a/tests/fault_injector/test_fault_injector.py
+++ b/tests/fault_injector/test_fault_injector.py
@@ -1,15 +1,16 @@
 import pytest
 
 from src.fault_injector.fault_injector import FaultInjector
-from src.fault_injector.fault_types.fault import Fault
-from src.fault_injector.fault_types.platform_blocked_fault import PlatformBlockedFault
-from src.fault_injector.fault_types.track_blocked_fault import TrackBlockedFault
+
+# pylint: disable=protected-access
 
 
 class TestFaultInjector:
     """tests the method of the fault injector component"""
 
     class MockFault:
+        """ A mock fault class to test the fault injector component
+        """
         received_ticks: int = 0
         last_tick: int
 

--- a/tests/fault_injector/test_fault_strategies.py
+++ b/tests/fault_injector/test_fault_strategies.py
@@ -12,8 +12,8 @@ from src.fault_injector.fault_strategies import (
 
 
 class TestFaultStrategies:
-    """ Test fault strategies
-    """
+    """Test fault strategies"""
+
     @pytest.fixture
     def regular_ticks(self):
         return (4, 109)

--- a/tests/fault_injector/test_fault_strategies.py
+++ b/tests/fault_injector/test_fault_strategies.py
@@ -12,6 +12,8 @@ from src.fault_injector.fault_strategies import (
 
 
 class TestFaultStrategies:
+    """ Test fault strategies
+    """
     @pytest.fixture
     def regular_ticks(self):
         return (4, 109)
@@ -334,7 +336,7 @@ class TestFaultStrategies:
             if random_fault_strategy.should_inject(
                 tick, random_configuration, injected
             ):
-                assert tick in random_inject_ticks and injected == False
+                assert tick in random_inject_ticks and not injected
 
     def test_resolve_random_strategy(
         self,
@@ -349,4 +351,4 @@ class TestFaultStrategies:
             if random_fault_strategy.should_resolve(
                 tick, random_configuration, injected
             ):
-                assert tick in random_resolve_ticks and injected == True
+                assert tick in random_resolve_ticks and injected

--- a/tests/fault_injector/test_table_fault_configurations.py
+++ b/tests/fault_injector/test_table_fault_configurations.py
@@ -1,6 +1,3 @@
-from uuid import UUID
-
-import marshmallow as marsh
 import peewee
 import pytest
 

--- a/tests/fault_injector/test_train_prio_fault.py
+++ b/tests/fault_injector/test_train_prio_fault.py
@@ -82,7 +82,10 @@ class TestTrainPrioFault:
     def test_resolve_train_not_in_simulation(
         self, tick, train_prio_fault: TrainPrioFault, train: Train
     ):
-        """tests that nothing happens when resolving the TrainPrioFault while the affected train is not in the simulation"""
+        """tests that nothing happens when resolving the TrainPrioFault while
+        the affected train is not in the simulation
+        """
+
         train_prio_fault.train = train
         train_prio_fault.old_prio = 3
         train.train_type.priority = 5
@@ -90,7 +93,7 @@ class TestTrainPrioFault:
             train_prio_fault.get_train_or_none(
                 train_prio_fault.simulation_object_updater, train.identifier
             )
-            == None
+            is None
         )
         train_prio_fault.resolve_fault(tick)
         assert train.train_type.priority == 5

--- a/tests/fault_injector/test_train_speed_fault.py
+++ b/tests/fault_injector/test_train_speed_fault.py
@@ -13,6 +13,8 @@ from src.wrapper.simulation_object_updating_component import (
 from src.wrapper.simulation_objects import Train
 from tests.decorators import recreate_db_setup
 
+# pylint: disable=protected-access
+
 
 class TestTrainSpeedFault:
     """Tests for TrainSpeedFault"""
@@ -97,7 +99,10 @@ class TestTrainSpeedFault:
     def test_resolve_train_not_in_simulation(
         self, tick, train_speed_fault: TrainSpeedFault, train: Train
     ):
-        """tests that nothing happens when resolving the TrainSpeedFault while the affected train is not in the simulation"""
+        """tests that nothing happens when resolving the TrainSpeedFault
+        while the affected train is not in the simulation
+        """
+
         train_speed_fault.train = train
         train_speed_fault.old_speed = 3
         train.train_type._max_speed = 5
@@ -105,7 +110,7 @@ class TestTrainSpeedFault:
             train_speed_fault.get_train_or_none(
                 train_speed_fault.simulation_object_updater, train.identifier
             )
-            == None
+            is None
         )
         train_speed_fault.resolve_fault(tick)
         assert train.train_type.max_speed == 5

--- a/tests/implementor/test_impl_simulation.py
+++ b/tests/implementor/test_impl_simulation.py
@@ -8,6 +8,9 @@ from src.spawner.spawner import SpawnerConfiguration
 
 
 class TestSimulationImplementor:
+    """ Tests for SimulationImplementor
+    """
+
     def test_get_all_simulation_ids(self, token):
         simulation = SimulationConfiguration()
         simulation.save()
@@ -30,16 +33,16 @@ class TestSimulationImplementor:
 
         def verify_references(key: str):
             """
-            Verifies that the references between the simulation configuration and the component configuration exist
+            Verifies that the references between the simulation configuration
+            and the component configuration exist
+
             :param key: The key of the component configuration
             """
             assert set(simulation_configuration_data[key]) == set(
-                [
-                    getattr(reference, f"{key}_configuration").id
-                    for reference in getattr(
-                        simulation_configuration, f"{key}_configuration_references"
-                    )
-                ]
+                getattr(reference, f"{key}_configuration").id
+                for reference in getattr(
+                    simulation_configuration, f"{key}_configuration_references"
+                )
             )
 
         verify_references("platform_blocked_fault")
@@ -74,13 +77,11 @@ class TestSimulationImplementor:
         assert status == 200
 
         def verify_references(key: str):
-            set(result[key]) == set(
-                [
-                    str(getattr(reference, f"{key}_configuration").id)
-                    for reference in getattr(
-                        simulation_configuration_full, f"{key}_configuration_references"
-                    )
-                ]
+            assert set(result[key]) == set(
+                str(getattr(reference, f"{key}_configuration").id)
+                for reference in getattr(
+                    simulation_configuration_full, f"{key}_configuration_references"
+                )
             )
 
         verify_references("platform_blocked_fault")

--- a/tests/implementor/test_impl_simulation.py
+++ b/tests/implementor/test_impl_simulation.py
@@ -8,8 +8,7 @@ from src.spawner.spawner import SpawnerConfiguration
 
 
 class TestSimulationImplementor:
-    """ Tests for SimulationImplementor
-    """
+    """Tests for SimulationImplementor"""
 
     def test_get_all_simulation_ids(self, token):
         simulation = SimulationConfiguration()

--- a/tests/implementor/test_impl_spawner.py
+++ b/tests/implementor/test_impl_spawner.py
@@ -7,6 +7,9 @@ from src.spawner.spawner import (
 
 
 class TestSpawnerConfiguration:
+    """ Tests for SpawnerConfiguration
+    """
+
     def test_get_single_spawner_configuration(self, token, spawner_configuration):
         result, status = impl.component.get_spawner_configuration(
             {"identifier": str(spawner_configuration.id)}, token
@@ -93,7 +96,7 @@ class TestSpawnerConfiguration:
         assert str(config.id) in result
         assert str(another_config.id) not in result
 
-    def test_create_spawner_configuration(token, spawner_configuration_data):
+    def test_create_spawner_configuration(self, token, spawner_configuration_data):
         response = impl.component.create_spawner_configuration(
             spawner_configuration_data, token
         )
@@ -113,7 +116,7 @@ class TestSpawnerConfiguration:
             assert schedule.id in spawner_configuration_data["schedule"]
 
     def test_create_spawner_configuration_not_found(
-        token,
+        self, token,
     ):
         response = impl.component.create_spawner_configuration(
             {"schedule": ["00000000-0000-0000-0000-000000000000"]}, token

--- a/tests/implementor/test_impl_spawner.py
+++ b/tests/implementor/test_impl_spawner.py
@@ -7,8 +7,7 @@ from src.spawner.spawner import (
 
 
 class TestSpawnerConfiguration:
-    """ Tests for SpawnerConfiguration
-    """
+    """Tests for SpawnerConfiguration"""
 
     def test_get_single_spawner_configuration(self, token, spawner_configuration):
         result, status = impl.component.get_spawner_configuration(
@@ -116,7 +115,8 @@ class TestSpawnerConfiguration:
             assert schedule.id in spawner_configuration_data["schedule"]
 
     def test_create_spawner_configuration_not_found(
-        self, token,
+        self,
+        token,
     ):
         response = impl.component.create_spawner_configuration(
             {"schedule": ["00000000-0000-0000-0000-000000000000"]}, token

--- a/tests/implementor/test_impl_track_speed_limit_fault.py
+++ b/tests/implementor/test_impl_track_speed_limit_fault.py
@@ -8,8 +8,7 @@ from src.fault_injector.fault_configurations.track_speed_limit_fault_configurati
 
 
 class TestTrackSpeedLimitFaultConfiguration:
-    """ Test for TrackSpeedLimitFaultConfiguration
-    """
+    """Test for TrackSpeedLimitFaultConfiguration"""
 
     def test_get_all_track_speed_limit_fault_configuration_ids(
         self, token, track_speed_limit_fault_configuration_data

--- a/tests/implementor/test_impl_track_speed_limit_fault.py
+++ b/tests/implementor/test_impl_track_speed_limit_fault.py
@@ -8,6 +8,9 @@ from src.fault_injector.fault_configurations.track_speed_limit_fault_configurati
 
 
 class TestTrackSpeedLimitFaultConfiguration:
+    """ Test for TrackSpeedLimitFaultConfiguration
+    """
+
     def test_get_all_track_speed_limit_fault_configuration_ids(
         self, token, track_speed_limit_fault_configuration_data
     ):
@@ -22,7 +25,7 @@ class TestTrackSpeedLimitFaultConfiguration:
         assert status == 200
         assert str(config.id) in result
 
-    def test_get_all_track_speed_limit_fault_configuration_ids(
+    def test_get_all_track_speed_limit_fault_configuration_ids2(
         self,
         token,
         track_speed_limit_fault_configuration_data,
@@ -49,7 +52,7 @@ class TestTrackSpeedLimitFaultConfiguration:
         assert str(another_config.id) not in result
 
     def test_create_track_speed_limit_fault_configuration(
-        token, track_speed_limit_fault_configuration_data
+        self, token, track_speed_limit_fault_configuration_data
     ):
         response = impl.component.create_track_speed_limit_fault_configuration(
             track_speed_limit_fault_configuration_data, token
@@ -110,6 +113,8 @@ class TestTrackSpeedLimitFaultConfiguration:
             .where(TrackSpeedLimitFaultConfiguration.id == config.id)
             .exists()
         )
+
+    # pylint: disable=unused-argument
 
     def test_delete_track_speed_limit_fault_configuration_not_found(
         self,

--- a/tests/implementor/test_run.py
+++ b/tests/implementor/test_run.py
@@ -12,6 +12,9 @@ from src.implementor.models import Run
 @pytest.mark.usefixtures("celery_session_app")
 @pytest.mark.usefixtures("celery_session_worker")
 class TestRunImplementor:
+    """ Tests for RunImplementor
+    """
+
     def test_get_all_simulation_ids(self, token, empty_simulation_configuration):
         run = Run.create(simulation_configuration=empty_simulation_configuration)
         result, status = impl.run.get_all_run_ids({}, token)
@@ -49,6 +52,8 @@ class TestRunImplementor:
         assert status == 404
         assert result == "Simulation not found"
 
+    # pylint: disable=too-many-locals
+
     # Test skipped, because the fixtures of celery aren't working properly
     # That's why we have to use the real celery app instead and cannot mock the components
     @patch("src.interlocking_component.route_controller.RouteController.next_tick")
@@ -68,7 +73,8 @@ class TestRunImplementor:
     @patch("src.fault_injector.fault_types.train_speed_fault.TrainSpeedFault.next_tick")
     @patch("src.fault_injector.fault_types.train_prio_fault.TrainPrioFault.next_tick")
     @patch(
-        "src.wrapper.simulation_object_updating_component.SimulationObjectUpdatingComponent.next_tick"
+        "src.wrapper.simulation_object_updating_component"
+        ".SimulationObjectUpdatingComponent.next_tick"
     )
     @pytest.mark.skip(reason="Celery fixtures not working properly")
     def test_create_run(
@@ -113,7 +119,7 @@ class TestRunImplementor:
     # Test skipped, because the fixtures of celery aren't working properly
     # That's why we have to use the real celery app instead and cannot mock the components
     @pytest.mark.skip(reason="Celery fixtures not working properly")
-    def test_get_run(token, empty_simulation_configuration, monkeypatch):
+    def test_get_run(self, token, empty_simulation_configuration, monkeypatch):
         monkeypatch.setattr(
             "src.interlocking_component.route_controller.RouteController.next_tick",
             lambda: None,
@@ -143,7 +149,7 @@ class TestRunImplementor:
     # Test skipped, because the fixtures of celery aren't working properly
     # That's why we have to use the real celery app instead and cannot mock the components
     @pytest.mark.skip(reason="Celery fixtures not working properly")
-    def test_delete_run(token, empty_simulation_configuration, monkeypatch):
+    def test_delete_run(self, token, empty_simulation_configuration, monkeypatch):
         monkeypatch.setattr(
             "src.interlocking_component.route_controller.RouteController.next_tick",
             lambda: None,

--- a/tests/implementor/test_run.py
+++ b/tests/implementor/test_run.py
@@ -12,8 +12,7 @@ from src.implementor.models import Run
 @pytest.mark.usefixtures("celery_session_app")
 @pytest.mark.usefixtures("celery_session_worker")
 class TestRunImplementor:
-    """ Tests for RunImplementor
-    """
+    """Tests for RunImplementor"""
 
     def test_get_all_simulation_ids(self, token, empty_simulation_configuration):
         run = Run.create(simulation_configuration=empty_simulation_configuration)

--- a/tests/implementor/test_table_run.py
+++ b/tests/implementor/test_table_run.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-import marshmallow as marsh
 import peewee
 import pytest
 

--- a/tests/implementor/test_table_simulation_configuration.py
+++ b/tests/implementor/test_table_simulation_configuration.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-import marshmallow as marsh
 import peewee
 import pytest
 

--- a/tests/spawner/test_schedule_configuration.py
+++ b/tests/spawner/test_schedule_configuration.py
@@ -1,4 +1,3 @@
-import marshmallow as marsh
 import peewee
 import pytest
 
@@ -64,7 +63,9 @@ class TestScheduleConfigurationModel:
     [({})],
 )
 class TestScheduleConfigurationXSimulationPlatformFail:
-    """Test that the TestScheduleConfigurationXSimulationPlatformFail fails when fields are missing"""
+    """Test that the TestScheduleConfigurationXSimulationPlatformFail
+    fails when fields are missing
+    """
 
     @recreate_db_setup
     def setup_method(self):

--- a/tests/spawner/test_smard_api.py
+++ b/tests/spawner/test_smard_api.py
@@ -12,6 +12,8 @@ from tests.decorators import recreate_db_setup
     [({})],
 )
 class TestSmardApiIndexFail:
+    """Test the SmardApiIndex class."""
+
     @recreate_db_setup
     def setup_method(self):
         pass
@@ -26,6 +28,8 @@ class TestSmardApiIndexFail:
 
 @pytest.mark.parametrize("obj", [({"timestamp": datetime(2015, 1, 19, 0, 0)})])
 class TestSmardApiIndexModel:
+    """Test the SmardApiIndex class."""
+
     @recreate_db_setup
     def setup_method(self):
         pass
@@ -43,6 +47,8 @@ class TestSmardApiIndexModel:
     [({})],
 )
 class TestSmardApiEntryFail:
+    """Test the SmardApiEntry class."""
+
     @recreate_db_setup
     def setup_method(self):
         pass
@@ -59,6 +65,8 @@ class TestSmardApiEntryFail:
     "obj", [({"timestamp": datetime(2015, 1, 19, 0, 0), "value": 42.0})]
 )
 class TestSmardApiEntryModel:
+    """Test the SmardApiEntry class."""
+
     _index: SmardApiIndex
 
     @recreate_db_setup
@@ -102,15 +110,6 @@ class TestSmardApi:
         demand_strategy_not_available_past_interval: tuple[datetime, datetime],
     ):
         start, end = demand_strategy_not_available_past_interval
-        availability = monkeypatched_smard_api.data_availability(start, end)
-        assert not availability.available
-
-    def test_no_data_available(
-        self,
-        monkeypatched_smard_api: object,
-        demand_strategy_not_available_future_interval: tuple[datetime, datetime],
-    ):
-        start, end = demand_strategy_not_available_future_interval
         availability = monkeypatched_smard_api.data_availability(start, end)
         assert not availability.available
 

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -150,20 +150,6 @@ class TestSpawnerConfigurationXSimulationConfiguration:
     def setup_method(self):
         pass
 
-    @pytest.mark.usefixtures("simulation_configuration, spawner_configuration")
-    def test_creation(
-        self,
-        simulation_configuration: SimulationConfiguration,
-        spawner_configuration: SpawnerConfiguration,
-    ):
-        spawner_x_simulation = SpawnerConfigurationXSimulationConfiguration(
-            spawner_configuration=spawner_configuration,
-            simulation_configuration=simulation_configuration,
-        )
-        spawner_x_simulation.save()
-        assert spawner_x_simulation.spawner_configuration == spawner_configuration
-        assert spawner_x_simulation.simulation_configuration == simulation_configuration
-
     def test_back_references(
         self,
         simulation_configuration: SimulationConfiguration,

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -68,6 +68,8 @@ class TestSpawner:
         regular_strategy_frequency: int,
         random_strategy_spawn_ticks: list[int],
     ):
+        # pylint: disable=protected-access
+
         regular_spawn_ticks = list(
             range(
                 strategy_start_tick, strategy_end_tick + 1, regular_strategy_frequency
@@ -141,7 +143,7 @@ class TestSpawnerConfigurationXSchedule:
         )
 
 
-class SpawnerConfigurationXSimulationConfiguration:
+class TestSpawnerConfigurationXSimulationConfiguration:
     """Tests for the SpawnerConfigurationXSimulationConfiguration"""
 
     @recreate_db_setup
@@ -156,11 +158,11 @@ class SpawnerConfigurationXSimulationConfiguration:
     ):
         spawner_x_simulation = SpawnerConfigurationXSimulationConfiguration(
             spawner_configuration=spawner_configuration,
-            schedule_configuration=simulation_configuration,
+            simulation_configuration=simulation_configuration,
         )
         spawner_x_simulation.save()
         assert spawner_x_simulation.spawner_configuration == spawner_configuration
-        assert spawner_x_simulation.schedule_configuration == simulation_configuration
+        assert spawner_x_simulation.simulation_configuration == simulation_configuration
 
     def test_back_references(
         self,
@@ -169,7 +171,7 @@ class SpawnerConfigurationXSimulationConfiguration:
     ):
         spawner_x_simulation = SpawnerConfigurationXSimulationConfiguration(
             spawner_configuration=spawner_configuration,
-            schedule_configuration=simulation_configuration,
+            simulation_configuration=simulation_configuration,
         )
         spawner_x_simulation.save()
         assert len(simulation_configuration.spawner_configuration_references) == 1
@@ -182,25 +184,3 @@ class SpawnerConfigurationXSimulationConfiguration:
             spawner_configuration.simulation_configuration_references[0]
             == spawner_x_simulation
         )
-
-    @pytest.mark.usefixtures("simulation_configuration, spawner_configuration")
-    def test_serialization(
-        self,
-        simulation_configuration: SimulationConfiguration,
-        spawner_configuration: SpawnerConfiguration,
-    ):
-        spawner_x_simulation = SpawnerConfigurationXSimulationConfiguration(
-            spawner_configuration=spawner_configuration,
-            simulation_configuration=simulation_configuration,
-        )
-        spawner_x_simulation.save()
-        obj_dict = spawner_x_simulation.to_dict()
-        del obj_dict["created_at"]
-        del obj_dict["updated_at"]
-        del obj_dict["readable_id"]
-
-        assert obj_dict == {
-            "id": str(spawner_x_simulation.id),
-            "spawner_configuration": str(spawner_x_simulation.id),
-            "schedule_configuration": str(spawner_x_simulation.id),
-        }

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -173,8 +173,7 @@ def configured_souc(
 @pytest.fixture
 def infrastructure_provider() -> SumoInfrastructureProvider:
     class IPMock:
-        """ Mock for the infrastructure provider
-        """
+        """Mock for the infrastructure provider"""
 
         def train_drove_onto_track(self, train: Train, edge: Edge):
             pass
@@ -186,8 +185,7 @@ def infrastructure_provider() -> SumoInfrastructureProvider:
 
 
 class MockRouteController:
-    """ Mock for the route controller
-    """
+    """Mock for the route controller"""
 
     def set_spawn_fahrstrasse(self, start: Track, end: Track):
         print(start.identifier, end.identifier, start.identifier == "7df3b-1-re")

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -11,7 +11,7 @@ from src.interlocking_component.infrastructure_provider import (
 from src.wrapper.simulation_object_updating_component import (
     SimulationObjectUpdatingComponent,
 )
-from src.wrapper.simulation_objects import Edge, Platform, Signal, Switch, Track, Train
+from src.wrapper.simulation_objects import Edge, Platform, Switch, Track, Train
 from src.wrapper.train_builder import TrainBuilder
 
 
@@ -21,11 +21,11 @@ def results(monkeypatch):
         def subscription_results():
             return defaultdict(int)
 
-        dict = defaultdict(subscription_results)
+        dict_ = defaultdict(subscription_results)
         edge_dict = defaultdict(int)
         edge_dict[constants.VAR_ROAD_ID] = "cfc57-0"
-        dict["fake-sim-train"] = edge_dict
-        return dict
+        dict_["fake-sim-train"] = edge_dict
+        return dict_
 
     monkeypatch.setattr(
         simulation, "getAllSubscriptionResults", get_subscription_result
@@ -173,6 +173,9 @@ def configured_souc(
 @pytest.fixture
 def infrastructure_provider() -> SumoInfrastructureProvider:
     class IPMock:
+        """ Mock for the infrastructure provider
+        """
+
         def train_drove_onto_track(self, train: Train, edge: Edge):
             pass
 
@@ -183,6 +186,9 @@ def infrastructure_provider() -> SumoInfrastructureProvider:
 
 
 class MockRouteController:
+    """ Mock for the route controller
+    """
+
     def set_spawn_fahrstrasse(self, start: Track, end: Track):
         print(start.identifier, end.identifier, start.identifier == "7df3b-1-re")
         if start.identifier == "7df3b-1-re":

--- a/tests/wrapper/test_simulation_object_updating_component.py
+++ b/tests/wrapper/test_simulation_object_updating_component.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from traci import trafficlight
 

--- a/tests/wrapper/test_simulation_objects.py
+++ b/tests/wrapper/test_simulation_objects.py
@@ -1,13 +1,9 @@
-import os
 from uuid import uuid4
 
 import pytest
-from traci import constants, edge, trafficlight, vehicle
+from traci import constants
 
-from src.wrapper.simulation_object_updating_component import (
-    SimulationObjectUpdatingComponent,
-)
-from src.wrapper.simulation_objects import Edge, Platform, Signal, Switch, Track, Train
+from src.wrapper.simulation_objects import Signal, Switch, Train
 
 
 class TestSignal:

--- a/tests/wrapper/test_train_spawner.py
+++ b/tests/wrapper/test_train_spawner.py
@@ -1,7 +1,5 @@
 from typing import Tuple
 
-import pytest
-
 from src.wrapper.simulation_object_updating_component import (
     SimulationObjectUpdatingComponent,
 )


### PR DESCRIPTION
Fixes #512 

I added `__init__.py` to all test folders in order to enable linting for the tests. I then fixed all linting errors.

## PR checklist

- [ ] Acceptance criteria fulfilled
- [ ] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
