### PR TITLE
`recalculate_all_routes` uses right parameter

### DIFF
--- a/src/interlocking_component/route_controller.py
+++ b/src/interlocking_component/route_controller.py
@@ -712,6 +712,8 @@ class RouteController(Component):
         self.route_queues.routes_waiting_for_reservations = []
         trains: list[Train] = self.simulation_object_updating_component.trains
         for train in trains:
-            for interlocking_route in self._get_interlocking_routes_for_edge(train.edge):
+            for interlocking_route in self._get_interlocking_routes_for_edge(
+                train.edge
+            ):
                 self._free_fahrstrasse(train, interlocking_route)
             self.set_fahrstrasse(train, train.edge)

--- a/src/interlocking_component/route_controller.py
+++ b/src/interlocking_component/route_controller.py
@@ -712,5 +712,6 @@ class RouteController(Component):
         self.route_queues.routes_waiting_for_reservations = []
         trains: list[Train] = self.simulation_object_updating_component.trains
         for train in trains:
-            self._free_fahrstrasse(train, train.route)
+            for interlocking_route in self._get_interlocking_routes_for_edge(train.edge):
+                self._free_fahrstrasse(train, interlocking_route)
             self.set_fahrstrasse(train, train.edge)


### PR DESCRIPTION
Fixes #554

`recalculate_all_routes` will most likely still not always work. Setting a fahrstrasse only works when the train is on specific edges in the simualtion. We may keep this branch to try to imropve tha, but that is a bigger issue.

## PR checklist

- [ ] Acceptance criteria fulfilled
- [ ] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
