### PR TITLE
Refactor: Move serialization logic to to_dict()

### DIFF
--- a/src/implementor/component.py
+++ b/src/implementor/component.py
@@ -706,18 +706,12 @@ def get_spawner_configuration(options, token):
     :param token: Token object of the current user
 
     """
-    config_id = options["identifier"]
-    configs = SpawnerConfiguration.select().where(SpawnerConfiguration.id == config_id)
+    identifier = options["identifier"]
+    configs = SpawnerConfiguration.select().where(SpawnerConfiguration.id == identifier)
     if not configs.exists():
         return "Id not found", 404
     config = configs.get()
-    config_data = config.to_dict()
-    schedules = [
-        str(reference.schedule_configuration_id.id)
-        for reference in config.schedule_configuration_references
-    ]
-
-    return {**config_data, "schedule": schedules}, 200
+    return config.to_dict(), 200
 
 
 def delete_spawner_configuration(options, token):

--- a/src/implementor/models.py
+++ b/src/implementor/models.py
@@ -22,7 +22,55 @@ class SimulationConfiguration(SerializableBaseModel):
 
     def to_dict(self):
         data = super().to_dict()
-        return {"description": self.description, **data}
+        spawner_ids = [
+            str(reference.spawner_configuration.id)
+            for reference in self.spawner_configuration_references
+        ]
+        # Should be only one spawner
+        spawner_id = spawner_ids[0] if len(spawner_ids) > 0 else None
+
+        platform_blocked_fault_ids = [
+            str(reference.platform_blocked_fault_configuration.id)
+            for reference in self.platform_blocked_fault_configuration_references
+        ]
+
+        schedule_blocked_fault_ids = [
+            str(reference.schedule_blocked_fault_configuration.id)
+            for reference in self.schedule_blocked_fault_configuration_references
+        ]
+
+        track_blocked_fault_ids = [
+            str(reference.track_blocked_fault_configuration.id)
+            for reference in self.track_blocked_fault_configuration_references
+        ]
+
+        track_speed_limit_fault_ids = [
+            str(reference.track_speed_limit_fault_configuration.id)
+            for reference in self.track_speed_limit_fault_configuration_references
+        ]
+
+        train_speed_fault_ids = [
+            str(reference.train_speed_fault_configuration.id)
+            for reference in self.train_speed_fault_configuration_references
+        ]
+
+        train_prio_fault_ids = [
+            str(reference.train_prio_fault_configuration.id)
+            for reference in self.train_prio_fault_configuration_references
+        ]
+        run_ids = [str(run.id) for run in self.runs]
+        return {
+            "description": self.description,
+            "spawner": spawner_id,
+            "platform_blocked_fault": platform_blocked_fault_ids,
+            "schedule_blocked_fault": schedule_blocked_fault_ids,
+            "track_blocked_fault": track_blocked_fault_ids,
+            "track_speed_limit_fault": track_speed_limit_fault_ids,
+            "train_speed_fault": train_speed_fault_ids,
+            "train_prio_fault": train_prio_fault_ids,
+            "runs": run_ids,
+            **data,
+        }
 
 
 class Run(SerializableBaseModel):

--- a/src/implementor/models.py
+++ b/src/implementor/models.py
@@ -24,6 +24,8 @@ class SimulationConfiguration(SerializableBaseModel):
         data = super().to_dict()
         spawner_ids = [
             str(reference.spawner_configuration.id)
+            # It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.spawner_configuration_references
         ]
         # Should be only one spawner
@@ -31,33 +33,46 @@ class SimulationConfiguration(SerializableBaseModel):
 
         platform_blocked_fault_ids = [
             str(reference.platform_blocked_fault_configuration.id)
+            # It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.platform_blocked_fault_configuration_references
         ]
 
         schedule_blocked_fault_ids = [
             str(reference.schedule_blocked_fault_configuration.id)
+            # It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.schedule_blocked_fault_configuration_references
         ]
 
         track_blocked_fault_ids = [
             str(reference.track_blocked_fault_configuration.id)
+            # It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.track_blocked_fault_configuration_references
         ]
 
         track_speed_limit_fault_ids = [
             str(reference.track_speed_limit_fault_configuration.id)
+            # It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.track_speed_limit_fault_configuration_references
         ]
 
         train_speed_fault_ids = [
             str(reference.train_speed_fault_configuration.id)
+            # It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.train_speed_fault_configuration_references
         ]
 
         train_prio_fault_ids = [
             str(reference.train_prio_fault_configuration.id)
+            #  It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.train_prio_fault_configuration_references
         ]
+        # pylint: disable-next=no-member
         run_ids = [str(run.id) for run in self.runs]
         return {
             "description": self.description,

--- a/src/implementor/simulation.py
+++ b/src/implementor/simulation.py
@@ -167,56 +167,7 @@ def get_simulation_configuration(options, token):
         return "Simulation not found", 404
 
     simulation_configuration = simulation_configurations.get()
-
-    spawner_ids = [
-        str(reference.spawner_configuration.id)
-        for reference in simulation_configuration.spawner_configuration_references
-    ]
-    spawner_id = spawner_ids[0]
-
-    platform_blocked_fault_ids = [
-        str(reference.platform_blocked_fault_configuration.id)
-        for reference in simulation_configuration.platform_blocked_fault_configuration_references
-    ]
-
-    schedule_blocked_fault_ids = [
-        str(reference.schedule_blocked_fault_configuration.id)
-        for reference in simulation_configuration.schedule_blocked_fault_configuration_references
-    ]
-
-    track_blocked_fault_ids = [
-        str(reference.track_blocked_fault_configuration.id)
-        for reference in simulation_configuration.track_blocked_fault_configuration_references
-    ]
-
-    track_speed_limit_fault_ids = [
-        str(reference.track_speed_limit_fault_configuration.id)
-        for reference in simulation_configuration.track_speed_limit_fault_configuration_references
-    ]
-
-    train_speed_fault_ids = [
-        str(reference.train_speed_fault_configuration.id)
-        for reference in simulation_configuration.train_speed_fault_configuration_references
-    ]
-
-    train_prio_fault_ids = [
-        str(reference.train_prio_fault_configuration.id)
-        for reference in simulation_configuration.train_prio_fault_configuration_references
-    ]
-    run_ids = [str(run.id) for run in simulation_configuration.runs]
-
-    return {
-        "id": str(simulation_configuration.id),
-        "description": simulation_configuration.description,
-        "spawner": spawner_id,
-        "platform_blocked_fault": platform_blocked_fault_ids,
-        "schedule_blocked_fault": schedule_blocked_fault_ids,
-        "track_blocked_fault": track_blocked_fault_ids,
-        "track_speed_limit_fault": track_speed_limit_fault_ids,
-        "train_speed_fault": train_speed_fault_ids,
-        "train_prio_fault": train_prio_fault_ids,
-        "runs": run_ids,
-    }, 200
+    return simulation_configuration.to_dict(), 200
 
 
 def update_simulation_configuration(options, body, token):

--- a/src/spawner/spawner.py
+++ b/src/spawner/spawner.py
@@ -19,6 +19,17 @@ class SpawnerConfiguration(SerializableBaseModel):
     This class has no fields except the `id` which is needed by the `Spawner`.
     """
 
+    def to_dict(self):
+        data = super().to_dict()
+        schedules = [
+            str(reference.schedule_configuration_id.id)
+            for reference in self.schedule_configuration_references
+        ]
+        return {
+            "schedule": schedules,
+            **data,
+        }
+
 
 class SpawnerConfigurationXSchedule(BaseModel):
     """Reference table class for m:n relation

--- a/src/spawner/spawner.py
+++ b/src/spawner/spawner.py
@@ -23,6 +23,8 @@ class SpawnerConfiguration(SerializableBaseModel):
         data = super().to_dict()
         schedules = [
             str(reference.schedule_configuration_id.id)
+            # It is a peewee method
+            # pylint: disable-next=no-member
             for reference in self.schedule_configuration_references
         ]
         return {

--- a/tests/spawner/test_spawner.py
+++ b/tests/spawner/test_spawner.py
@@ -111,9 +111,13 @@ class TestSpawnerConfiguration:
         del obj_dict["updated_at"]
         del obj_dict["readable_id"]
 
-        assert obj_dict == {
-            "id": str(spawner_configuration.id),
-        }
+        schedules = [
+            str(reference.schedule_configuration_id.id)
+            for reference in spawner_configuration.schedule_configuration_references
+        ]
+        assert set(obj_dict["schedule"]) == set(schedules)
+        del obj_dict["schedule"]
+        assert obj_dict == {"id": str(spawner_configuration.id)}
 
 
 class TestSpawnerConfigurationXSchedule:


### PR DESCRIPTION
Fixes #<n>

Moves serialization logic to `to_dict()` methods.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
