### PR TITLE
Set default values for train and track `max_speed`

### DIFF
--- a/src/wrapper/simulation_objects.py
+++ b/src/wrapper/simulation_objects.py
@@ -6,6 +6,9 @@ from typing import List, Optional, Tuple, Union
 from sumolib import net
 from traci import FatalTraCIError, constants, edge, trafficlight, vehicle
 
+MAX_TRAIN_SPEED: float = 22.222222
+MAX_TRACK_SPEED: float = 22.222222
+
 
 class SimulationObject(ABC):
     """This class represents an object inside the sumo simulation.
@@ -471,6 +474,8 @@ class Edge(SimulationObject):
         result._from = simulation_object.getFromNode().getID()
         result._to = simulation_object.getToNode().getID()
 
+        result._max_speed = MAX_TRACK_SPEED
+
         return result
 
     def add_simulation_connections(self) -> None:
@@ -753,9 +758,12 @@ class Train(SimulationObject):
             """
             return Train.TrainType(instance, name=train_type)
 
-        def __init__(self, identifier, name: str = None):
+        def __init__(
+            self, identifier, name: str = None, max_speed: float = MAX_TRAIN_SPEED
+        ):
             SimulationObject.__init__(self, identifier)
             self._name = name
+            self._max_speed = max_speed
 
         def update(self, data: dict) -> None:
             self._max_speed = data[constants.VAR_MAXSPEED]
@@ -891,6 +899,7 @@ class Train(SimulationObject):
 
         if not from_simulator:
             self._add_to_simulation(identifier, train_type, route_id)
+        self.train_type.max_speed = self.train_type._max_speed
 
     def _add_to_simulation(self, identifier: str, train_type: str, route: str):
         vehicle.add(identifier, routeID=route, typeID=train_type)

--- a/tests/fault_injector/conftest.py
+++ b/tests/fault_injector/conftest.py
@@ -124,15 +124,23 @@ def train_add(monkeypatch):
 
     monkeypatch.setattr(vehicle, "add", add_train)
 
+@pytest.fixture
+def max_speed(monkeypatch):
+    # pylint: disable-next=unused-argument
+    def set_max_speed(train_id: str, speed: float):
+        pass
+
+    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
 
 @pytest.fixture
 # pylint: disable-next=unused-argument
-def train(train_add) -> Train:
+def train(train_add, max_speed) -> Train:
     return Train(
         identifier="fault injector train",
         train_type="cargo",
         timetable=["platform-1", "platform-2"],
     )
+
 
 
 @pytest.fixture

--- a/tests/fault_injector/conftest.py
+++ b/tests/fault_injector/conftest.py
@@ -124,6 +124,7 @@ def train_add(monkeypatch):
 
     monkeypatch.setattr(vehicle, "add", add_train)
 
+
 @pytest.fixture
 def max_speed(monkeypatch):
     # pylint: disable-next=unused-argument
@@ -131,6 +132,7 @@ def max_speed(monkeypatch):
         pass
 
     monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
+
 
 @pytest.fixture
 # pylint: disable-next=unused-argument
@@ -140,7 +142,6 @@ def train(train_add, max_speed) -> Train:
         train_type="cargo",
         timetable=["platform-1", "platform-2"],
     )
-
 
 
 @pytest.fixture

--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -300,6 +300,7 @@ def train_add(monkeypatch):
 
     monkeypatch.setattr(vehicle, "add", add_train)
 
+
 @pytest.fixture
 def max_speed(monkeypatch):
     # pylint: disable-next=unused-argument

--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -300,10 +300,18 @@ def train_add(monkeypatch):
 
     monkeypatch.setattr(vehicle, "add", add_train)
 
+@pytest.fixture
+def max_speed(monkeypatch):
+    # pylint: disable-next=unused-argument
+    def set_max_speed(train_id: str, speed: float):
+        pass
+
+    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
+
 
 @pytest.fixture
 # pylint: disable-next=unused-argument
-def train(train_add) -> Train:
+def train(train_add, max_speed) -> Train:
     return Train(
         identifier="fault injector train",
         train_type="cargo",

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -275,7 +275,10 @@ class MockRouteController:
 
 @pytest.fixture
 def spawner(
-    configured_souc: SimulationObjectUpdatingComponent, train_add, train_subscribe, max_speed
+    configured_souc: SimulationObjectUpdatingComponent,
+    train_add,
+    train_subscribe,
+    max_speed,
 ) -> Tuple[SimulationObjectUpdatingComponent, TrainBuilder]:
     # pylint: disable=unused-argument
     return (configured_souc, TrainBuilder(configured_souc, MockRouteController()))

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -61,13 +61,13 @@ def max_speed(monkeypatch):
     monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
 
 
-#@pytest.fixture
-#def speed_update(monkeypatch):
-#    def set_max_speed(identifier: str, speed: float) -> None:
-#        assert identifier is not None
-#        assert speed > 0
-#
-#    monkeypatch.setattr(edge, "setMaxSpeed", set_max_speed)
+@pytest.fixture
+def speed_update(monkeypatch):
+    def set_max_speed(identifier: str, speed: float) -> None:
+        assert identifier is not None
+        assert speed > 0
+
+    monkeypatch.setattr(edge, "setMaxSpeed", set_max_speed)
 
 
 @pytest.fixture
@@ -138,13 +138,13 @@ def edge2() -> Edge:
     return Edge("bf53d-1")
 
 
-@pytest.fixture
-def max_speed(monkeypatch):
-    # pylint: disable-next=unused-argument
-    def set_max_speed(train_id: str, speed: float):
-        pass
-
-    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
+# @pytest.fixture
+# def max_speed(monkeypatch):
+#    # pylint: disable-next=unused-argument
+#    def set_max_speed(train_id: str, speed: float):
+#        pass
+#
+#    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
 
 
 @pytest.fixture

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -137,12 +137,20 @@ def edge1_re() -> Edge:
 def edge2() -> Edge:
     return Edge("bf53d-1")
 
+@pytest.fixture
+def max_speed(monkeypatch):
+    # pylint: disable-next=unused-argument
+    def set_max_speed(train_id: str, speed: float):
+        pass
+
+    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
 
 @pytest.fixture
 def train(
     train_add,
     train_route_update,
     train_set_route_id,
+    max_speed,
     configured_souc: SimulationObjectUpdatingComponent,
     edge1: Edge,
 ) -> Train:

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -61,13 +61,13 @@ def max_speed(monkeypatch):
     monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
 
 
-@pytest.fixture
-def speed_update(monkeypatch):
-    def set_max_speed(identifier: str, speed: float) -> None:
-        assert identifier is not None
-        assert speed > 0
-
-    monkeypatch.setattr(edge, "setMaxSpeed", set_max_speed)
+#@pytest.fixture
+#def speed_update(monkeypatch):
+#    def set_max_speed(identifier: str, speed: float) -> None:
+#        assert identifier is not None
+#        assert speed > 0
+#
+#    monkeypatch.setattr(edge, "setMaxSpeed", set_max_speed)
 
 
 @pytest.fixture

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -275,7 +275,7 @@ class MockRouteController:
 
 @pytest.fixture
 def spawner(
-    configured_souc: SimulationObjectUpdatingComponent, train_add, train_subscribe
+    configured_souc: SimulationObjectUpdatingComponent, train_add, train_subscribe, max_speed
 ) -> Tuple[SimulationObjectUpdatingComponent, TrainBuilder]:
     # pylint: disable=unused-argument
     return (configured_souc, TrainBuilder(configured_souc, MockRouteController()))

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -137,6 +137,7 @@ def edge1_re() -> Edge:
 def edge2() -> Edge:
     return Edge("bf53d-1")
 
+
 @pytest.fixture
 def max_speed(monkeypatch):
     # pylint: disable-next=unused-argument
@@ -144,6 +145,7 @@ def max_speed(monkeypatch):
         pass
 
     monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
+
 
 @pytest.fixture
 def train(

--- a/tests/wrapper/conftest.py
+++ b/tests/wrapper/conftest.py
@@ -138,15 +138,6 @@ def edge2() -> Edge:
     return Edge("bf53d-1")
 
 
-# @pytest.fixture
-# def max_speed(monkeypatch):
-#    # pylint: disable-next=unused-argument
-#    def set_max_speed(train_id: str, speed: float):
-#        pass
-#
-#    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
-
-
 @pytest.fixture
 def train(
     train_add,

--- a/tests/wrapper/test_simulation_objects.py
+++ b/tests/wrapper/test_simulation_objects.py
@@ -161,7 +161,7 @@ class TestTrain:
         train.timetable = ["asdf"]
         assert train.timetable == ["asdf"]
 
-    def test_spawning(self, train_add):
+    def test_spawning(self, train_add, max_speed):
         # pylint: disable=unused-argument
         Train(
             identifier="fancy-rb-001",
@@ -214,7 +214,7 @@ class TestTrain:
         assert len(train.add_subscriptions()) > 0
 
     def test_spawn_loaded_net(
-        self, configured_souc: SimulationObjectUpdatingComponent, train_add
+        self, configured_souc: SimulationObjectUpdatingComponent, train_add, max_speed
     ):
         # pylint: disable=unused-argument
         p1_id = Platform("station-1", edge_id="a57e4-1", platform_id="station-1")
@@ -228,7 +228,7 @@ class TestTrain:
         )
 
     def test_current_platform(
-        self, configured_souc: SimulationObjectUpdatingComponent, train_add
+        self, configured_souc: SimulationObjectUpdatingComponent, train_add, max_speed
     ):
         # pylint: disable=unused-argument
         p1_id = Platform("station-1", edge_id="bf53d-0", platform_id="station-1")


### PR DESCRIPTION
Fixes #571 

Sets default values for `max_speed` attribute of trains and tracks. This is necessary in order to change these values with fault injection.

## PR checklist

- [ ] Acceptance criteria fulfilled
- [ ] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
