### PR TITLE
Tests: Refactor API tests to check for implementor calls.

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -30,7 +30,10 @@ def fixture_clear_hashed_token():
 @pytest.fixture(name="admin_token", autouse=True)
 def fixture_admin_token(clear_admin_token):
     hashed_token = hashlib.sha256(clear_admin_token.encode()).hexdigest()
-    name = "admin"
+    token = Token.select().where(Token.hashedToken == hashed_token)
+    if token.exists():
+        return token.get()
+    name = "user"
     permission = "admin"
     return Token.create(name=name, permission=permission, hashedToken=hashed_token)
 
@@ -43,6 +46,9 @@ def fixture_not_hashed_token():
 @pytest.fixture(name="token", autouse=True)
 def fixture_token(clear_token):
     hashed_token = hashlib.sha256(clear_token.encode()).hexdigest()
+    token = Token.select().where(Token.hashedToken == hashed_token)
+    if token.exists():
+        return token.get()
     name = "user"
     permission = "user"
     return Token.create(name=name, permission=permission, hashedToken=hashed_token)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -4,6 +4,8 @@ from src.implementor.models import Token
 from src.implementor.token import hash_token
 
 
+# Initialization of the database is done when client is called
+# pylint: disable=unused-argument
 def test_first_token(client):
     clear_token = os.getenv("FIRST_ADMIN_TOKEN")
     hashed_token = hash_token(clear_token)

--- a/tests/api/test_api_demand_schedule.py
+++ b/tests/api/test_api_demand_schedule.py
@@ -1,6 +1,8 @@
 import uuid
-
+from unittest.mock import Mock
 import pytest
+from src import implementor as impl
+import datetime
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 
@@ -10,57 +12,123 @@ class TestApiCoalDemandSchedule:
     Test the /schedule/coal-demand endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(impl.schedule, "get_all_schedule_ids", mock)
         response = client.get(
             "/schedule/coal-demand", headers={TOKEN_HEADER: clear_token}
+        )
+        assert mock.call_args.args == (
+            {
+                "simulationId": None,
+                "strategy": "coal-demand",
+            },
+            token,
         )
         assert response.status_code == 200
 
     @pytest.mark.parametrize(
-        "data",
+        "data, expected_data",
         [
-            {
-                "schedule_type": "TrainSchedule",
-                "demand_strategy_power_station": "power_station",
-                "demand_strategy_scaling_factor": 2,
-                "demand_strategy_start_datetime": "2022-01-01T00:00:00+00:00",
-                "platforms": ["platform1", "platform2"],
-            },
-            {
-                "schedule_type": "TrainSchedule",
-                "demand_strategy_power_station": "power_station",
-                "demand_strategy_scaling_factor": 2,
-                "demand_strategy_start_datetime": "2022-01-01T00:00:00+00:00",
-                "strategy_start_tick": 1,
-                "strategy_end_tick": 100,
-                "train_schedule_train_type": "passenger",
-                "platforms": ["platform1", "platform2"],
-            },
+            [
+                {
+                    "schedule_type": "TrainSchedule",
+                    "demand_strategy_power_station": "power_station",
+                    "demand_strategy_scaling_factor": 2.0,
+                    "demand_strategy_start_datetime": "2022-01-01T00:00:00+00:00",
+                    "platforms": ["platform1", "platform2"],
+                },
+                {
+                    "schedule_type": "TrainSchedule",
+                    "demand_strategy_power_station": "power_station",
+                    "demand_strategy_scaling_factor": 2.0,
+                    "demand_strategy_start_datetime": datetime.datetime(
+                        2022,
+                        1,
+                        1,
+                        0,
+                        0,
+                        tzinfo=datetime.timezone(datetime.timedelta(0), "+0000"),
+                    ),
+                    "platforms": ["platform1", "platform2"],
+                },
+            ],
+            [
+                {
+                    "schedule_type": "TrainSchedule",
+                    "demand_strategy_power_station": "power_station",
+                    "demand_strategy_scaling_factor": 2.0,
+                    "demand_strategy_start_datetime": "2022-01-01T00:00:00+00:00",
+                    "strategy_start_tick": 1,
+                    "strategy_end_tick": 100,
+                    "train_schedule_train_type": "passenger",
+                    "platforms": ["platform1", "platform2"],
+                },
+                {
+                    "schedule_type": "TrainSchedule",
+                    "demand_strategy_power_station": "power_station",
+                    "demand_strategy_scaling_factor": 2.0,
+                    "demand_strategy_start_datetime": datetime.datetime(
+                        2022,
+                        1,
+                        1,
+                        0,
+                        0,
+                        tzinfo=datetime.timezone(datetime.timedelta(0), "+0000"),
+                    ),
+                    "strategy_start_tick": 1,
+                    "strategy_end_tick": 100,
+                    "train_schedule_train_type": "passenger",
+                    "platforms": ["platform1", "platform2"],
+                },
+            ],
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, expected_data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(impl.schedule, "create_schedule", mock)
         response = client.post(
             "/schedule/coal-demand", headers={TOKEN_HEADER: clear_token}, json=data
         )
         assert response.status_code != 422
+        assert mock.call_args.args == (
+            expected_data,
+            {"strategy": "coal-demand"},
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(impl.schedule, "create_schedule", mock)
         response = client.post(
             "/schedule/coal-demand", headers={TOKEN_HEADER: clear_token}, json=data
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(impl.schedule, "get_schedule", mock)
         response = client.get(
             f"/schedule/coal-demand/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id), "strategy": "coal-demand"},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(impl.schedule, "delete_schedule", mock)
         response = client.delete(
             f"/schedule/coal-demand/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id), "strategy": "coal-demand"},
+            token,
+        )

--- a/tests/api/test_api_demand_schedule.py
+++ b/tests/api/test_api_demand_schedule.py
@@ -5,10 +5,12 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete_schedule, verify_get_single_schedule
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 
 
+# pylint: disable=duplicate-code
 class TestApiCoalDemandSchedule:
     """
     Test the /schedule/coal-demand endpoint
@@ -110,27 +112,15 @@ class TestApiCoalDemandSchedule:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(impl.schedule, "get_schedule", mock)
-        response = client.get(
-            f"/schedule/coal-demand/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id), "strategy": "coal-demand"},
-            token,
+        verify_get_single_schedule(
+            client, "schedule/coal-demand", clear_token, token, mock, "coal-demand"
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(impl.schedule, "delete_schedule", mock)
-        response = client.delete(
-            f"/schedule/coal-demand/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id), "strategy": "coal-demand"},
-            token,
+        verify_delete_schedule(
+            client, "schedule/coal-demand", clear_token, token, mock, "coal-demand"
         )

--- a/tests/api/test_api_demand_schedule.py
+++ b/tests/api/test_api_demand_schedule.py
@@ -1,8 +1,10 @@
+import datetime
 import uuid
 from unittest.mock import Mock
+
 import pytest
+
 from src import implementor as impl
-import datetime
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_platform_blocked_fault.py
+++ b/tests/api/test_api_platform_blocked_fault.py
@@ -1,9 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
-import pytest
 
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_platform_blocked_fault.py
+++ b/tests/api/test_api_platform_blocked_fault.py
@@ -1,4 +1,7 @@
 import uuid
+from unittest.mock import Mock
+from src import implementor as impl
+import pytest
 
 import pytest
 
@@ -10,12 +13,22 @@ class TestApiPlatformBlockedFault:
     Test the /component/fault-injection/platform-blocked-fault endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(
+            impl.component, "get_all_platform_blocked_fault_configuration_ids", mock
+        )
         response = client.get(
             "/component/fault-injection/platform-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
         )
         assert response.status_code == 200
+        assert mock.call_args.args == (
+            {
+                "simulationId": None,
+            },
+            token,
+        )
 
     @pytest.mark.parametrize(
         "data",
@@ -32,35 +45,66 @@ class TestApiPlatformBlockedFault:
             },
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_platform_blocked_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/platform-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        assert mock.call_args.args == (
+            data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=(uuid.uuid4(), 200))
+        monkeypatch.setattr(
+            impl.component, "create_platform_blocked_fault_configuration", mock
+        )
         response = client.post(
             "/component/fault-injection/platform-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(
+            impl.component, "get_platform_blocked_fault_configuration", mock
+        )
         response = client.get(
             f"/component/fault-injection/platform-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(
+            impl.component, "delete_platform_blocked_fault_configuration", mock
+        )
         response = client.delete(
             f"/component/fault-injection/platform-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_platform_blocked_fault.py
+++ b/tests/api/test_api_platform_blocked_fault.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiPlatformBlockedFault:
@@ -78,33 +81,27 @@ class TestApiPlatformBlockedFault:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(
             impl.component, "get_platform_blocked_fault_configuration", mock
         )
-        response = client.get(
-            f"/component/fault-injection/platform-blocked-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "component/fault-injection/platform-blocked-fault",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(
             impl.component, "delete_platform_blocked_fault_configuration", mock
         )
-        response = client.delete(
-            f"/component/fault-injection/platform-blocked-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "component/fault-injection/platform-blocked-fault",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/test_api_random_schedule.py
+++ b/tests/api/test_api_random_schedule.py
@@ -2,9 +2,9 @@ import uuid
 from unittest.mock import Mock
 
 import pytest
-from tests.api.utils import verify_get_single_schedule, verify_delete_schedule
 
 from src import implementor as impl
+from tests.api.utils import verify_delete_schedule, verify_get_single_schedule
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_random_schedule.py
+++ b/tests/api/test_api_random_schedule.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_random_schedule.py
+++ b/tests/api/test_api_random_schedule.py
@@ -2,10 +2,13 @@ import uuid
 from unittest.mock import Mock
 
 import pytest
+from tests.api.utils import verify_get_single_schedule, verify_delete_schedule
 
 from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiRandomSchedule:
@@ -70,27 +73,15 @@ class TestApiRandomSchedule:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(impl.schedule, "get_schedule", mock)
-        response = client.get(
-            f"/schedule/random/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id), "strategy": "random"},
-            token,
+        verify_get_single_schedule(
+            client, "schedule/random", clear_token, token, mock, "random"
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(impl.schedule, "delete_schedule", mock)
-        response = client.delete(
-            f"/schedule/random/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id), "strategy": "random"},
-            token,
+        verify_delete_schedule(
+            client, "schedule/random", clear_token, token, mock, "random"
         )

--- a/tests/api/test_api_regular_schedule.py
+++ b/tests/api/test_api_regular_schedule.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete_schedule, verify_get_single_schedule
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiRegularSchedule:
@@ -68,27 +71,25 @@ class TestApiRegularSchedule:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(impl.schedule, "get_schedule", mock)
-        response = client.get(
-            f"/schedule/regular/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id), "strategy": "regular"},
+        verify_get_single_schedule(
+            client,
+            "schedule/regular",
+            clear_token,
             token,
+            mock,
+            "regular",
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(impl.schedule, "delete_schedule", mock)
-        response = client.delete(
-            f"/schedule/regular/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id), "strategy": "regular"},
+        verify_delete_schedule(
+            client,
+            "schedule/regular",
+            clear_token,
             token,
+            mock,
+            "regular",
         )

--- a/tests/api/test_api_regular_schedule.py
+++ b/tests/api/test_api_regular_schedule.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_run.py
+++ b/tests/api/test_api_run.py
@@ -1,5 +1,6 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
@@ -10,28 +11,57 @@ class TestApiRun:
     Test the /run endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(impl.run, "get_all_run_ids", mock)
         response = client.get("/run", headers={TOKEN_HEADER: clear_token})
         assert response.status_code == 200
+        assert mock.call_args.args == (
+            {
+                "simulationId": None,
+            },
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{"simulation_configuration": str(uuid.uuid4())}])
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(impl.run, "create_run", mock)
         response = client.post("/run", headers={TOKEN_HEADER: clear_token}, json=data)
-        assert response.status_code != 422
+        assert response.status_code == 201
+        assert mock.call_args.args == (
+            {"simulation_configuration": (uuid.UUID(data["simulation_configuration"]))},
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=(uuid.uuid4(), 200))
+        monkeypatch.setattr(impl.run, "create_run", mock)
         response = client.post("/run", headers={TOKEN_HEADER: clear_token}, json=data)
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(impl.run, "get_run", mock)
         response = client.get(f"/run/{object_id}", headers={TOKEN_HEADER: clear_token})
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(impl.run, "delete_run", mock)
         response = client.delete(
             f"/run/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_run.py
+++ b/tests/api/test_api_run.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_run.py
+++ b/tests/api/test_api_run.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiRun:
@@ -45,25 +48,23 @@ class TestApiRun:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(impl.run, "get_run", mock)
-        response = client.get(f"/run/{object_id}", headers={TOKEN_HEADER: clear_token})
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "run",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(impl.run, "delete_run", mock)
-        response = client.delete(
-            f"/run/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "run",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/test_api_schedule_blocked_fault.py
+++ b/tests/api/test_api_schedule_blocked_fault.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiScheduleBlockedFault:
@@ -80,33 +83,27 @@ class TestApiScheduleBlockedFault:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(
             impl.component, "get_schedule_blocked_fault_configuration", mock
         )
-        response = client.get(
-            f"/component/fault-injection/schedule-blocked-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "component/fault-injection/schedule-blocked-fault",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(
             impl.component, "delete_schedule_blocked_fault_configuration", mock
         )
-        response = client.delete(
-            f"/component/fault-injection/schedule-blocked-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "component/fault-injection/schedule-blocked-fault",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/test_api_schedule_blocked_fault.py
+++ b/tests/api/test_api_schedule_blocked_fault.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_schedule_blocked_fault.py
+++ b/tests/api/test_api_schedule_blocked_fault.py
@@ -1,5 +1,6 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
@@ -10,12 +11,22 @@ class TestApiScheduleBlockedFault:
     Test the /component/fault-injection/schedule-blocked-fault endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(
+            impl.component, "get_all_schedule_blocked_fault_configuration_ids", mock
+        )
         response = client.get(
             "/component/fault-injection/schedule-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
         )
         assert response.status_code == 200
+        assert mock.call_args.args == (
+            {
+                "simulationId": None,
+            },
+            token,
+        )
 
     @pytest.mark.parametrize(
         "data",
@@ -32,35 +43,68 @@ class TestApiScheduleBlockedFault:
             },
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_schedule_blocked_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/schedule-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        assert mock.call_args.args == (
+            data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_schedule_blocked_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/schedule-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(
+            impl.component, "get_schedule_blocked_fault_configuration", mock
+        )
         response = client.get(
             f"/component/fault-injection/schedule-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(
+            impl.component, "delete_schedule_blocked_fault_configuration", mock
+        )
         response = client.delete(
             f"/component/fault-injection/schedule-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_simulation.py
+++ b/tests/api/test_api_simulation.py
@@ -1,8 +1,21 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+
+def get_expected_data(data, exception=list()):
+    expected_data = dict()
+    for key, val in data.items():
+        if key in exception:
+            expected_data[key] = val
+        elif isinstance(val, list):
+            expected_data[key] = [uuid.UUID(v) for v in val]
+        else:
+            expected_data[key] = uuid.UUID(val)
+    return expected_data
 
 
 class TestApiSimulation:
@@ -10,72 +23,114 @@ class TestApiSimulation:
     Test the /simulation endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(impl.simulation, "get_all_simulation_ids", mock)
         response = client.get("/simulation", headers={TOKEN_HEADER: clear_token})
         assert response.status_code == 200
+        assert mock.call_args.args == (token,)
 
     @pytest.mark.parametrize(
         "data",
         [
-            {"spawner": uuid.uuid4()},
+            {"spawner": str(uuid.uuid4())},
             {
-                "spawner": uuid.uuid4(),
+                "spawner": str(uuid.uuid4()),
                 "description": "test-description",
-                "platform_blocked_fault": [uuid.uuid4()],
-                "schedule_blocked_fault": [uuid.uuid4()],
-                "track_blocked_fault": [uuid.uuid4()],
-                "track_speed_limit_fault": [uuid.uuid4()],
-                "train_speed_fault": [uuid.uuid4()],
-                "train_prio_fault": [uuid.uuid4()],
+                "platform_blocked_fault": [str(uuid.uuid4())],
+                "schedule_blocked_fault": [str(uuid.uuid4())],
+                "track_blocked_fault": [str(uuid.uuid4())],
+                "track_speed_limit_fault": [str(uuid.uuid4())],
+                "train_speed_fault": [str(uuid.uuid4())],
+                "train_prio_fault": [str(uuid.uuid4())],
             },
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.simulation,
+            "create_simulation_configuration",
+            mock,
+        )
         response = client.post(
             "/simulation", headers={TOKEN_HEADER: clear_token}, json=data
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        expected_data = get_expected_data(data, ["description"])
+        assert mock.call_args.args == (
+            expected_data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.simulation,
+            "create_simulation_configuration",
+            mock,
+        )
         response = client.post(
             "/simulation", headers={TOKEN_HEADER: clear_token}, json=data
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(impl.simulation, "get_simulation_configuration", mock)
         response = client.get(
             f"/simulation/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
     @pytest.mark.parametrize(
         "data",
         [
             {},
             {
-                "spawner": uuid.uuid4(),
+                "spawner": str(uuid.uuid4()),
                 "description": "test-description",
-                "platform_blocked_fault": [uuid.uuid4()],
-                "schedule_blocked_fault": [uuid.uuid4()],
-                "track_blocked_fault": [uuid.uuid4()],
-                "track_speed_limit_fault": [uuid.uuid4()],
-                "train_speed_fault": [uuid.uuid4()],
-                "train_prio_fault": [uuid.uuid4()],
+                "platform_blocked_fault": [str(uuid.uuid4())],
+                "schedule_blocked_fault": [str(uuid.uuid4())],
+                "track_blocked_fault": [str(uuid.uuid4())],
+                "track_speed_limit_fault": [str(uuid.uuid4())],
+                "train_speed_fault": [str(uuid.uuid4())],
+                "train_prio_fault": [str(uuid.uuid4())],
             },
         ],
     )
-    def test_update(self, client, clear_token, data):
+    def test_update(self, client, clear_token, token, data, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(impl.simulation, "update_simulation_configuration", mock)
         response = client.put(
             f"/simulation/{object_id}", headers={TOKEN_HEADER: clear_token}, json=data
         )
-        assert response.status_code == 404
 
-    def test_delete(self, client, clear_token):
+        expected_data = get_expected_data(data, exception=["description"])
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            expected_data,
+            token,
+        )
+
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(impl.simulation, "delete_simulation_configuration", mock)
         response = client.delete(
             f"/simulation/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_simulation.py
+++ b/tests/api/test_api_simulation.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_spawner.py
+++ b/tests/api/test_api_spawner.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiSpawner:
@@ -32,7 +35,6 @@ class TestApiSpawner:
             "/component/spawner", headers={TOKEN_HEADER: clear_token}, json=data
         )
         assert response.status_code == 201
-        # TODO map every existing key to uuid
         expected_data = {
             "schedule": [uuid.UUID(identifier) for identifier in data["schedule"]],
         }
@@ -56,35 +58,31 @@ class TestApiSpawner:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(
             impl.component,
             "get_spawner_configuration",
             mock,
         )
-        response = client.get(
-            f"/component/spawner/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "component/spawner",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(
             impl.component,
             "delete_spawner_configuration",
             mock,
         )
-        response = client.delete(
-            f"/component/spawner/{object_id}", headers={TOKEN_HEADER: clear_token}
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "component/spawner",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/test_api_spawner.py
+++ b/tests/api/test_api_spawner.py
@@ -1,5 +1,6 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
@@ -10,36 +11,78 @@ class TestApiSpawner:
     Test the /component/spawner endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(impl.component, "get_all_spawner_configuration_ids", mock)
         response = client.get("/component/spawner", headers={TOKEN_HEADER: clear_token})
         assert response.status_code == 200
+        assert mock.call_args.args == ({"simulationId": None}, token)
 
-    @pytest.mark.parametrize(
-        "data", [{"schedule": ["00000000-0000-0000-0000-000000000000"]}]
-    )
-    def test_post(self, client, clear_token, data):
+    @pytest.mark.parametrize("data", [{"schedule": [str(uuid.uuid4())]}])
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_spawner_configuration",
+            mock,
+        )
         response = client.post(
             "/component/spawner", headers={TOKEN_HEADER: clear_token}, json=data
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        # TODO map every existing key to uuid
+        expected_data = {
+            "schedule": [uuid.UUID(identifier) for identifier in data["schedule"]],
+        }
+        assert mock.call_args.args == (
+            expected_data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_spawner_configuration",
+            mock,
+        )
         response = client.post(
             "/component/spawner", headers={TOKEN_HEADER: clear_token}, json=data
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(
+            impl.component,
+            "get_spawner_configuration",
+            mock,
+        )
         response = client.get(
             f"/component/spawner/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(
+            impl.component,
+            "delete_spawner_configuration",
+            mock,
+        )
         response = client.delete(
             f"/component/spawner/{object_id}", headers={TOKEN_HEADER: clear_token}
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_spawner.py
+++ b/tests/api/test_api_spawner.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_token.py
+++ b/tests/api/test_api_token.py
@@ -1,6 +1,8 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
+from src.implementor.permission import Permission
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 
@@ -11,29 +13,58 @@ class TestApiToken:
     """
 
     @pytest.mark.parametrize(
-        "data",
+        "data, expected_data",
         [
-            {"name": "user", "permission": "admin"},
-            {"name": "user", "permission": "user"},
+            [
+                {"name": "user", "permission": "admin"},
+                {"name": "user", "permission": Permission.ADMIN},
+            ],
+            [
+                {"name": "user", "permission": "user"},
+                {"name": "user", "permission": Permission.USER},
+            ],
         ],
     )
-    def test_post(self, client, clear_admin_token, data):
+    def test_post(
+        self, client, clear_admin_token, admin_token, data, expected_data, monkeypatch
+    ):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.token,
+            "create_token",
+            mock,
+        )
         response = client.post(
             "/token", headers={TOKEN_HEADER: clear_admin_token}, json=data
         )
         assert response.status_code == 201
+        assert mock.call_args.args == (expected_data, admin_token)
 
     @pytest.mark.parametrize("data", [{"name": "user", "permission": "user"}])
-    def test_post_no_permission(self, client, clear_token, data):
+    def test_post_no_permission(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.token,
+            "create_token",
+            mock,
+        )
         response = client.post("/token", headers={TOKEN_HEADER: clear_token}, json=data)
         assert response.status_code == 403
+        assert not mock.called
 
     @pytest.mark.parametrize("data", [{}, {"name": "user"}, {"permission": "invalid"}])
-    def test_post_invalid(self, client, clear_admin_token, data):
+    def test_post_invalid(self, client, clear_admin_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.token,
+            "create_token",
+            mock,
+        )
         response = client.post(
             "/token", headers={TOKEN_HEADER: clear_admin_token}, json=data
         )
         assert response.status_code == 422
+        assert not mock.called
 
     def test_get_all(self, client, clear_admin_token):
         response = client.get("/token", headers={TOKEN_HEADER: clear_admin_token})

--- a/tests/api/test_api_token.py
+++ b/tests/api/test_api_token.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 from src.implementor.permission import Permission
 
 TOKEN_HEADER = "bp2022-ap1-api-key"

--- a/tests/api/test_api_track_blocked_fault.py
+++ b/tests/api/test_api_track_blocked_fault.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiTrackBlockedFault:
@@ -78,33 +81,27 @@ class TestApiTrackBlockedFault:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(
             impl.component, "get_track_blocked_fault_configuration", mock
         )
-        response = client.get(
-            f"/component/fault-injection/track-blocked-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "component/fault-injection/track-blocked-fault",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(
             impl.component, "delete_track_blocked_fault_configuration", mock
         )
-        response = client.delete(
-            f"/component/fault-injection/track-blocked-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "component/fault-injection/track-blocked-fault",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/test_api_track_blocked_fault.py
+++ b/tests/api/test_api_track_blocked_fault.py
@@ -1,5 +1,6 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
@@ -10,12 +11,20 @@ class TestApiTrackBlockedFault:
     Test the /component/fault-injection/track-blocked-fault endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(
+            impl.component, "get_all_track_blocked_fault_configuration_ids", mock
+        )
         response = client.get(
             "/component/fault-injection/track-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
         )
         assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"simulationId": None},
+            token,
+        )
 
     @pytest.mark.parametrize(
         "data",
@@ -32,35 +41,68 @@ class TestApiTrackBlockedFault:
             },
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_track_blocked_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/track-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        assert mock.call_args.args == (
+            data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_track_blocked_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/track-blocked-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(
+            impl.component, "get_track_blocked_fault_configuration", mock
+        )
         response = client.get(
             f"/component/fault-injection/track-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(
+            impl.component, "delete_track_blocked_fault_configuration", mock
+        )
         response = client.delete(
             f"/component/fault-injection/track-blocked-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_track_blocked_fault.py
+++ b/tests/api/test_api_track_blocked_fault.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_track_speed_limit_fault.py
+++ b/tests/api/test_api_track_speed_limit_fault.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_track_speed_limit_fault.py
+++ b/tests/api/test_api_track_speed_limit_fault.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiTrackSpeedLimitFault:
@@ -84,33 +87,27 @@ class TestApiTrackSpeedLimitFault:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(
             impl.component, "get_track_speed_limit_fault_configuration", mock
         )
-        response = client.get(
-            f"/component/fault-injection/track-speed-limit-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "component/fault-injection/track-speed-limit-fault",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(
             impl.component, "delete_track_speed_limit_fault_configuration", mock
         )
-        response = client.delete(
-            f"/component/fault-injection/track-speed-limit-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "component/fault-injection/track-speed-limit-fault",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/test_api_track_speed_limit_fault.py
+++ b/tests/api/test_api_track_speed_limit_fault.py
@@ -1,5 +1,6 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
@@ -10,12 +11,20 @@ class TestApiTrackSpeedLimitFault:
     Test the /component/fault-injection/track-speed-limit-fault endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(
+            impl.component, "get_all_track_speed_limit_fault_configuration_ids", mock
+        )
         response = client.get(
             "/component/fault-injection/track-speed-limit-fault",
             headers={TOKEN_HEADER: clear_token},
         )
         assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"simulationId": None},
+            token,
+        )
 
     @pytest.mark.parametrize(
         "data",
@@ -38,35 +47,68 @@ class TestApiTrackSpeedLimitFault:
             },
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_track_speed_limit_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/track-speed-limit-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        assert mock.call_args.args == (
+            data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_track_speed_limit_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/track-speed-limit-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(
+            impl.component, "get_track_speed_limit_fault_configuration", mock
+        )
         response = client.get(
             f"/component/fault-injection/track-speed-limit-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(
+            impl.component, "delete_track_speed_limit_fault_configuration", mock
+        )
         response = client.delete(
             f"/component/fault-injection/track-speed-limit-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_train_prio_fault.py
+++ b/tests/api/test_api_train_prio_fault.py
@@ -1,5 +1,6 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
@@ -10,12 +11,20 @@ class TestApiTrainPrioFault:
     Test the /component/fault-injection/train-prio-fault endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(
+            impl.component, "get_all_train_prio_fault_configuration_ids", mock
+        )
         response = client.get(
             "/component/fault-injection/train-prio-fault",
             headers={TOKEN_HEADER: clear_token},
         )
         assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"simulationId": None},
+            token,
+        )
 
     @pytest.mark.parametrize(
         "data",
@@ -38,35 +47,66 @@ class TestApiTrainPrioFault:
             },
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_train_prio_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/train-prio-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        assert mock.call_args.args == (
+            data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_train_prio_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/train-prio-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(impl.component, "get_train_prio_fault_configuration", mock)
         response = client.get(
             f"/component/fault-injection/train-prio-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(
+            impl.component, "delete_train_prio_fault_configuration", mock
+        )
         response = client.delete(
             f"/component/fault-injection/train-prio-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_train_prio_fault.py
+++ b/tests/api/test_api_train_prio_fault.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
+
+# pylint: disable=duplicate-code
 
 
 class TestApiTrainPrioFault:
@@ -84,31 +87,25 @@ class TestApiTrainPrioFault:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(impl.component, "get_train_prio_fault_configuration", mock)
-        response = client.get(
-            f"/component/fault-injection/train-prio-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 200
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "component/fault-injection/train-prio-fault",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(
             impl.component, "delete_train_prio_fault_configuration", mock
         )
-        response = client.delete(
-            f"/component/fault-injection/train-prio-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "component/fault-injection/train-prio-fault",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/test_api_train_prio_fault.py
+++ b/tests/api/test_api_train_prio_fault.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_train_speed_fault.py
+++ b/tests/api/test_api_train_speed_fault.py
@@ -1,7 +1,9 @@
 import uuid
 from unittest.mock import Mock
-from src import implementor as impl
+
 import pytest
+
+from src import implementor as impl
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 

--- a/tests/api/test_api_train_speed_fault.py
+++ b/tests/api/test_api_train_speed_fault.py
@@ -1,5 +1,6 @@
 import uuid
-
+from unittest.mock import Mock
+from src import implementor as impl
 import pytest
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
@@ -10,12 +11,20 @@ class TestApiTrainSpeedFault:
     Test the /component/fault-injection/train-speed-fault endpoint
     """
 
-    def test_get_all(self, client, clear_token):
+    def test_get_all(self, client, clear_token, token, monkeypatch):
+        mock = Mock(return_value=([uuid.uuid4()], 200))
+        monkeypatch.setattr(
+            impl.component, "get_all_train_speed_fault_configuration_ids", mock
+        )
         response = client.get(
             "/component/fault-injection/train-speed-fault",
             headers={TOKEN_HEADER: clear_token},
         )
         assert response.status_code == 200
+        assert mock.call_args.args == (
+            {"simulationId": None},
+            token,
+        )
 
     @pytest.mark.parametrize(
         "data",
@@ -38,35 +47,65 @@ class TestApiTrainSpeedFault:
             },
         ],
     )
-    def test_post(self, client, clear_token, data):
+    def test_post(self, client, clear_token, token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_train_speed_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/train-speed-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
-        assert response.status_code != 422
+        assert response.status_code == 201
+        assert mock.call_args.args == (
+            data,
+            token,
+        )
 
     @pytest.mark.parametrize("data", [{}])
-    def test_post_invalid(self, client, clear_token, data):
+    def test_post_invalid(self, client, clear_token, data, monkeypatch):
+        mock = Mock(return_value=({"id": uuid.uuid4()}, 201))
+        monkeypatch.setattr(
+            impl.component,
+            "create_train_speed_fault_configuration",
+            mock,
+        )
         response = client.post(
             "/component/fault-injection/train-speed-fault",
             headers={TOKEN_HEADER: clear_token},
             json=data,
         )
         assert response.status_code == 422
+        assert not mock.called
 
-    def test_get_single(self, client, clear_token):
+    def test_get_single(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(dict(), 200))
+        monkeypatch.setattr(impl.component, "get_train_speed_fault_configuration", mock)
         response = client.get(
             f"/component/fault-injection/train-speed-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )
 
-    def test_delete(self, client, clear_token):
+    def test_delete(self, client, clear_token, token, monkeypatch):
         object_id = uuid.uuid4()
+        mock = Mock(return_value=(str(), 204))
+        monkeypatch.setattr(
+            impl.component, "delete_train_speed_fault_configuration", mock
+        )
         response = client.delete(
             f"/component/fault-injection/train-speed-fault/{object_id}",
             headers={TOKEN_HEADER: clear_token},
         )
-        assert response.status_code == 404
+        assert response.status_code == 204
+        assert mock.call_args.args == (
+            {"identifier": str(object_id)},
+            token,
+        )

--- a/tests/api/test_api_train_speed_fault.py
+++ b/tests/api/test_api_train_speed_fault.py
@@ -4,10 +4,12 @@ from unittest.mock import Mock
 import pytest
 
 from src import implementor as impl
+from tests.api.utils import verify_delete, verify_get_single
 
 TOKEN_HEADER = "bp2022-ap1-api-key"
 
 
+# pylint: disable=duplicate-code
 class TestApiTrainSpeedFault:
     """
     Test the /component/fault-injection/train-speed-fault endpoint
@@ -84,30 +86,25 @@ class TestApiTrainSpeedFault:
         assert not mock.called
 
     def test_get_single(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
-        mock = Mock(return_value=(dict(), 200))
+        mock = Mock(return_value=({}, 200))
         monkeypatch.setattr(impl.component, "get_train_speed_fault_configuration", mock)
-        response = client.get(
-            f"/component/fault-injection/train-speed-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_get_single(
+            client,
+            "component/fault-injection/train-speed-fault",
+            clear_token,
             token,
+            mock,
         )
 
     def test_delete(self, client, clear_token, token, monkeypatch):
-        object_id = uuid.uuid4()
         mock = Mock(return_value=(str(), 204))
         monkeypatch.setattr(
             impl.component, "delete_train_speed_fault_configuration", mock
         )
-        response = client.delete(
-            f"/component/fault-injection/train-speed-fault/{object_id}",
-            headers={TOKEN_HEADER: clear_token},
-        )
-        assert response.status_code == 204
-        assert mock.call_args.args == (
-            {"identifier": str(object_id)},
+        verify_delete(
+            client,
+            "component/fault-injection/train-speed-fault",
+            clear_token,
             token,
+            mock,
         )

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,0 +1,47 @@
+import uuid
+
+TOKEN_HEADER = "bp2022-ap1-api-key"
+
+
+def verify_get_single(client, route, clear_token, token, mock):
+    object_id = uuid.uuid4()
+    response = client.get(f"/{route}/{object_id}", headers={TOKEN_HEADER: clear_token})
+    assert response.status_code == 200
+    assert mock.call_args.args == (
+        {"identifier": str(object_id)},
+        token,
+    )
+
+
+def verify_delete(client, route, clear_token, token, mock):
+    object_id = uuid.uuid4()
+    response = client.delete(
+        f"/{route}/{object_id}", headers={TOKEN_HEADER: clear_token}
+    )
+    assert response.status_code == 204
+    assert mock.call_args.args == (
+        {"identifier": str(object_id)},
+        token,
+    )
+
+
+def verify_get_single_schedule(client, route, clear_token, token, mock, strategy):
+    object_id = uuid.uuid4()
+    response = client.get(f"/{route}/{object_id}", headers={TOKEN_HEADER: clear_token})
+    assert response.status_code == 200
+    assert mock.call_args.args == (
+        {"identifier": str(object_id), "strategy": strategy},
+        token,
+    )
+
+
+def verify_delete_schedule(client, route, clear_token, token, mock, strategy):
+    object_id = uuid.uuid4()
+    response = client.delete(
+        f"/{route}/{object_id}", headers={TOKEN_HEADER: clear_token}
+    )
+    assert response.status_code == 204
+    assert mock.call_args.args == (
+        {"identifier": str(object_id), "strategy": strategy},
+        token,
+    )


### PR DESCRIPTION
Fixes #516 

The API tests now check if the parsing process of the data is correct.
It tests if it calls the function with the correct arguments of the implementor.
Enables lint for API tests

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [x] Another dev reviewed and approved
