### PR TITLE
Tests: Enable lint for implementor tests

### DIFF
--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -1,7 +1,7 @@
 import hashlib
 
 import pytest
-
+from traci import vehicle
 from src.fault_injector.fault_configurations.platform_blocked_fault_configuration import (
     PlatformBlockedFaultConfiguration,
     PlatformBlockedFaultConfigurationXSimulationConfiguration,
@@ -292,8 +292,30 @@ def another_track_speed_limit_fault_configuration(
 
 
 @pytest.fixture
+def train_add(monkeypatch):
+    # definition of function set by the traci module
+    # pylint: disable-next=unused-argument disable-next=invalid-name
+    def add_train(identifier, routeID=None, typeID=None):
+        assert identifier is not None
+        assert typeID is not None
+
+    monkeypatch.setattr(vehicle, "add", add_train)
+
+
+@pytest.fixture
+def max_speed(monkeypatch):
+    # definition of function set by the traci module
+    # pylint: disable-next=unused-argument
+    def set_max_speed(train_id: str, speed: float):
+        pass
+
+    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
+
+
+@pytest.fixture
+# Need train_add and max_speed as fixtures to make sure that the traci module is patched
 # pylint: disable-next=unused-argument
-def train() -> Train:
+def train(train_add, max_speed) -> Train:
     return Train(
         identifier="fault injector train",
         train_type="cargo",

--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -1,7 +1,6 @@
 import hashlib
 
 import pytest
-from traci import vehicle
 
 from src.fault_injector.fault_configurations.platform_blocked_fault_configuration import (
     PlatformBlockedFaultConfiguration,
@@ -27,7 +26,7 @@ from src.fault_injector.fault_configurations.train_speed_fault_configuration imp
     TrainSpeedFaultConfiguration,
     TrainSpeedFaultConfigurationXSimulationConfiguration,
 )
-from src.implementor.models import Run, SimulationConfiguration, Token
+from src.implementor.models import SimulationConfiguration, Token
 from src.interlocking_component.interlocking_configuration import (
     InterlockingConfiguration,
 )
@@ -174,7 +173,7 @@ def another_spawner_configuration(
 
 
 @pytest.fixture
-def platform(edge: Edge, edge_re: Edge) -> Platform:
+def platform(edge: Edge) -> Platform:
     return Platform(
         "fault injector platform", platform_id="platform-1", edge_id=edge.identifier
     )
@@ -293,26 +292,8 @@ def another_track_speed_limit_fault_configuration(
 
 
 @pytest.fixture
-def train_add(monkeypatch):
-    def add_train(identifier, routeID=None, typeID=None):
-        assert identifier is not None
-        assert typeID is not None
-
-    monkeypatch.setattr(vehicle, "add", add_train)
-
-
-@pytest.fixture
-def max_speed(monkeypatch):
-    # pylint: disable-next=unused-argument
-    def set_max_speed(train_id: str, speed: float):
-        pass
-
-    monkeypatch.setattr(vehicle, "setMaxSpeed", set_max_speed)
-
-
-@pytest.fixture
 # pylint: disable-next=unused-argument
-def train(train_add, max_speed) -> Train:
+def train() -> Train:
     return Train(
         identifier="fault injector train",
         train_type="cargo",
@@ -342,23 +323,6 @@ def another_train_prio_fault_configuration(
     train_prio_fault_configuration_data,
 ):
     return TrainPrioFaultConfiguration.create(**train_prio_fault_configuration_data)
-
-
-# ------------- TrainSpeedLimitFaultConfiguration ----------------
-
-
-@pytest.fixture
-def train_speed_fault_configuration(
-    train: Train,
-) -> TrainSpeedFaultConfiguration:
-    return TrainSpeedFaultConfiguration.create(
-        start_time=40,
-        end_time=400,
-        description="test TrainSpeedFault",
-        affected_element_id=train.identifier,
-        new_speed=30,
-        strategy="regular",
-    )
 
 
 # ------------- TrainSpeedFaultConfiguration ----------------

--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -2,6 +2,7 @@ import hashlib
 
 import pytest
 from traci import vehicle
+
 from src.fault_injector.fault_configurations.platform_blocked_fault_configuration import (
     PlatformBlockedFaultConfiguration,
     PlatformBlockedFaultConfigurationXSimulationConfiguration,

--- a/tests/implementor/conftest.py
+++ b/tests/implementor/conftest.py
@@ -45,6 +45,7 @@ from src.spawner.spawner import (
 from src.wrapper.simulation_objects import Edge, Platform, Track, Train
 
 
+# pylint: disable=duplicate-code
 @pytest.fixture
 def token():
     clear_token = "token"

--- a/tests/implementor/test_impl_platform_blocked_fault.py
+++ b/tests/implementor/test_impl_platform_blocked_fault.py
@@ -21,10 +21,10 @@ class TestPlatformBlockedFaultConfiguration:
             **platform_blocked_fault_configuration_data
         )
 
-        response = impl.component.get_all_platform_blocked_fault_configuration_ids(
-            {}, token
-        )
-        (result, status) = response
+        (
+            result,
+            status,
+        ) = impl.component.get_all_platform_blocked_fault_configuration_ids({}, token)
         assert status == 200
         assert str(config.id) in result
 
@@ -45,10 +45,12 @@ class TestPlatformBlockedFaultConfiguration:
             platform_blocked_fault_configuration=config,
         )
 
-        response = impl.component.get_all_platform_blocked_fault_configuration_ids(
+        (
+            result,
+            status,
+        ) = impl.component.get_all_platform_blocked_fault_configuration_ids(
             {"simulationId": str(empty_simulation_configuration.id)}, token
         )
-        (result, status) = response
 
         assert status == 200
         assert str(config.id) in result
@@ -57,10 +59,9 @@ class TestPlatformBlockedFaultConfiguration:
     def test_create_platform_blocked_fault_configuration(
         self, token, platform_blocked_fault_configuration_data
     ):
-        response = impl.component.create_platform_blocked_fault_configuration(
+        (result, status) = impl.component.create_platform_blocked_fault_configuration(
             platform_blocked_fault_configuration_data, token
         )
-        (result, status) = response
         assert status == 201
         assert result["id"]
         configs = PlatformBlockedFaultConfiguration.select().where(
@@ -80,10 +81,9 @@ class TestPlatformBlockedFaultConfiguration:
             **platform_blocked_fault_configuration_data
         )
 
-        response = impl.component.get_platform_blocked_fault_configuration(
+        (result, status) = impl.component.get_platform_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
         assert status == 200
         assert str(config.id) == result["id"]
         assert str(config.updated_at) == result["updated_at"]
@@ -104,10 +104,9 @@ class TestPlatformBlockedFaultConfiguration:
         config = PlatformBlockedFaultConfiguration.create(
             **platform_blocked_fault_configuration_data
         )
-        response = impl.component.delete_platform_blocked_fault_configuration(
+        (result, status) = impl.component.delete_platform_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
         assert status == 204
         assert result == "Deleted platform-blocked-fault configuration"
         assert (
@@ -121,10 +120,9 @@ class TestPlatformBlockedFaultConfiguration:
         token,
     ):
         object_id = uuid.uuid4()
-        response = impl.component.delete_platform_blocked_fault_configuration(
+        (result, status) = impl.component.delete_platform_blocked_fault_configuration(
             {"identifier": object_id}, token
         )
-        (result, status) = response
         assert status == 404
         assert result == "Id not found"
 
@@ -141,10 +139,9 @@ class TestPlatformBlockedFaultConfiguration:
             simulation_configuration=empty_simulation_configuration,
             platform_blocked_fault_configuration=config,
         )
-        response = impl.component.delete_platform_blocked_fault_configuration(
+        (result, status) = impl.component.delete_platform_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
         assert status == 400
         assert (
             result

--- a/tests/implementor/test_impl_platform_blocked_fault.py
+++ b/tests/implementor/test_impl_platform_blocked_fault.py
@@ -7,7 +7,13 @@ from src.fault_injector.fault_configurations.platform_blocked_fault_configuratio
 )
 
 
+# pylint: disable=duplicate-code
 class TestPlatformBlockedFaultConfiguration:
+    """
+    Tests for correct functionality of platform blocked fault configuration endpoint
+    if the input data is valid.
+    """
+
     def test_get_all_platform_blocked_fault_configuration_ids(
         self, token, platform_blocked_fault_configuration_data
     ):
@@ -22,7 +28,7 @@ class TestPlatformBlockedFaultConfiguration:
         assert status == 200
         assert str(config.id) in result
 
-    def test_get_all_platform_blocked_fault_configuration_ids(
+    def test_get_all_platform_blocked_fault_configuration_ids_with_simulation(
         self,
         token,
         platform_blocked_fault_configuration_data,
@@ -49,7 +55,7 @@ class TestPlatformBlockedFaultConfiguration:
         assert str(another_config.id) not in result
 
     def test_create_platform_blocked_fault_configuration(
-        token, platform_blocked_fault_configuration_data
+        self, token, platform_blocked_fault_configuration_data
     ):
         response = impl.component.create_platform_blocked_fault_configuration(
             platform_blocked_fault_configuration_data, token
@@ -113,7 +119,6 @@ class TestPlatformBlockedFaultConfiguration:
     def test_delete_platform_blocked_fault_configuration_not_found(
         self,
         token,
-        platform_blocked_fault_configuration_data,
     ):
         object_id = uuid.uuid4()
         response = impl.component.delete_platform_blocked_fault_configuration(

--- a/tests/implementor/test_impl_run.py
+++ b/tests/implementor/test_impl_run.py
@@ -10,10 +10,14 @@ from src.implementor.models import Run
 from src.logger.log_entry import LogEntry
 
 
+# pylint: disable=duplicate-code
 @pytest.mark.usefixtures("celery_session_app")
 @pytest.mark.usefixtures("celery_session_worker")
 class TestRunImplementor:
-    """Tests for RunImplementor"""
+    """
+    Tests for correct functionality of run endpoint
+    if the input data is valid.
+    """
 
     def test_get_all_simulation_ids(self, token, empty_simulation_configuration):
         run = Run.create(simulation_configuration=empty_simulation_configuration)

--- a/tests/implementor/test_impl_schedule.py
+++ b/tests/implementor/test_impl_schedule.py
@@ -5,7 +5,13 @@ from src.schedule.schedule_configuration import ScheduleConfiguration
 from src.spawner.spawner import SpawnerConfiguration, SpawnerConfigurationXSchedule
 
 
+# pylint: disable=duplicate-code
 class TestScheduleConfiguration:
+    """
+    Tests for correct functionality of schedule configuration endpoint
+    if the input data is valid.
+    """
+
     @pytest.mark.parametrize(
         "strategy, configuration_fixture, not_found_configuration_fixture",
         [
@@ -63,21 +69,17 @@ class TestScheduleConfiguration:
         configuration_data = request.getfixturevalue(configuration_data_fixture)
         strategy = configuration_data.pop("strategy_type")
         configuration_data["platforms"] = platform_ids
-        response = impl.schedule.create_schedule(
+        (result, status) = impl.schedule.create_schedule(
             configuration_data, {"strategy": strategy}, token
         )
-        (result, status) = response
         assert status == 201
         assert result["id"] is not None
-        config_id = result["id"]
-        config = ScheduleConfiguration.get_by_id(config_id)
+        config = ScheduleConfiguration.get_by_id(result["id"])
         assert config is not None
         assert config.strategy_type == strategy
         for key, value in configuration_data.items():
             assert getattr(config, key) == value
-        platform_reference = [
-            reference for reference in config.train_schedule_platform_references
-        ]
+        platform_reference = list(config.train_schedule_platform_references)
         for reference in platform_reference:
             platform_id = platform_ids[reference.index]
             assert platform_id == reference.simulation_platform_id
@@ -102,10 +104,9 @@ class TestScheduleConfiguration:
         configuration = request.getfixturevalue(configuration_fixture)
         strategy = configuration_data.pop("strategy_type")
 
-        response = impl.schedule.get_schedule(
+        (result, status) = impl.schedule.get_schedule(
             {"strategy": strategy, "identifier": str(configuration.id)}, token
         )
-        (result, status) = response
         assert status == 200
         configuration_data["strategy_type"] = strategy
         for key, item in configuration_data.items():

--- a/tests/implementor/test_impl_schedule.py
+++ b/tests/implementor/test_impl_schedule.py
@@ -45,8 +45,9 @@ class TestScheduleConfiguration:
             not_found_configuration_fixture
         )
 
-        response = impl.schedule.get_all_schedule_ids({"strategy": strategy}, token)
-        (result, status) = response
+        (result, status) = impl.schedule.get_all_schedule_ids(
+            {"strategy": strategy}, token
+        )
         assert status == 200
         assert str(configuration.id) in result
         assert str(not_found_configuration.id) not in result
@@ -124,14 +125,13 @@ class TestScheduleConfiguration:
         ],
     )
     def test_get_single_schedule_configuration_not_found(self, token, strategy):
-        response = impl.schedule.get_schedule(
+        (result, status) = impl.schedule.get_schedule(
             {
                 "strategy": strategy,
                 "identifier": "00000000-0000-0000-0000-000000000000",
             },
             token,
         )
-        (result, status) = response
         assert status == 404
         assert result == "Schedule not found"
 
@@ -147,10 +147,9 @@ class TestScheduleConfiguration:
         self, token, strategy, configuration_fixture, request: pytest.FixtureRequest
     ):
         configuration = request.getfixturevalue(configuration_fixture)
-        response = impl.schedule.delete_schedule(
+        (result, status) = impl.schedule.delete_schedule(
             {"strategy": strategy, "identifier": str(configuration.id)}, token
         )
-        (result, status) = response
         assert status == 204
         assert result == "Schedule deleted"
         configs = ScheduleConfiguration.select().where(
@@ -167,14 +166,13 @@ class TestScheduleConfiguration:
         ],
     )
     def test_delete_schedule_configuration_not_found(self, strategy, token):
-        response = impl.schedule.delete_schedule(
+        (result, status) = impl.schedule.delete_schedule(
             {
                 "strategy": strategy,
                 "identifier": "00000000-0000-0000-0000-000000000000",
             },
             token,
         )
-        (result, status) = response
         assert status == 404
         assert result == "Schedule not found"
 
@@ -196,10 +194,10 @@ class TestScheduleConfiguration:
             spawner_configuration_id=spawner,
             schedule_configuration_id=configuration,
         ).save()
-        response = impl.schedule.delete_schedule(
+        (result, status) = impl.schedule.delete_schedule(
             {"strategy": strategy, "identifier": str(configuration.id)}, token
         )
-        (result, status) = response
+
         assert status == 400
         assert (
             result == "Schedule configuration is referenced by a spawner configuration"

--- a/tests/implementor/test_impl_schedule_blocked_fault.py
+++ b/tests/implementor/test_impl_schedule_blocked_fault.py
@@ -8,7 +8,13 @@ from src.fault_injector.fault_configurations.schedule_blocked_fault_configuratio
 )
 
 
+# pylint: disable=duplicate-code
 class TestScheduleBlockedFaultConfiguration:
+    """
+    Tests for correct functionality of schedule blocked fault configuration endpoint
+    if the input data is valid.
+    """
+
     def test_get_all_schedule_blocked_fault_configuration_ids(
         self, token, schedule_blocked_fault_configuration_data
     ):
@@ -23,7 +29,7 @@ class TestScheduleBlockedFaultConfiguration:
         assert status == 200
         assert str(config.id) in result
 
-    def test_get_all_schedule_blocked_fault_configuration_ids(
+    def test_get_all_schedule_blocked_fault_configuration_ids_with_simulation(
         self,
         token,
         schedule_blocked_fault_configuration_data,
@@ -50,13 +56,12 @@ class TestScheduleBlockedFaultConfiguration:
         assert str(another_config.id) not in result
 
     def test_create_schedule_blocked_fault_configuration(
-        token, schedule_blocked_fault_configuration_data
+        self, token, schedule_blocked_fault_configuration_data
     ):
-        def compare(a: object, b: object) -> bool:
-            if isinstance(a, UUID) or isinstance(b, UUID):
-                return str(a) == str(b)
-            else:
-                return a == b
+        def compare(first: object, second: object) -> bool:
+            if isinstance(first, UUID) or isinstance(second, UUID):
+                return str(first) == str(second)
+            return first == second
 
         response = impl.component.create_schedule_blocked_fault_configuration(
             schedule_blocked_fault_configuration_data, token
@@ -121,7 +126,6 @@ class TestScheduleBlockedFaultConfiguration:
     def test_delete_schedule_blocked_fault_configuration_not_found(
         self,
         token,
-        schedule_blocked_fault_configuration_data,
     ):
         object_id = uuid.uuid4()
         response = impl.component.delete_schedule_blocked_fault_configuration(

--- a/tests/implementor/test_impl_schedule_blocked_fault.py
+++ b/tests/implementor/test_impl_schedule_blocked_fault.py
@@ -22,10 +22,10 @@ class TestScheduleBlockedFaultConfiguration:
             **schedule_blocked_fault_configuration_data
         )
 
-        response = impl.component.get_all_schedule_blocked_fault_configuration_ids(
-            {}, token
-        )
-        (result, status) = response
+        (
+            result,
+            status,
+        ) = impl.component.get_all_schedule_blocked_fault_configuration_ids({}, token)
         assert status == 200
         assert str(config.id) in result
 
@@ -46,10 +46,12 @@ class TestScheduleBlockedFaultConfiguration:
             schedule_blocked_fault_configuration=config,
         )
 
-        response = impl.component.get_all_schedule_blocked_fault_configuration_ids(
+        (
+            result,
+            status,
+        ) = impl.component.get_all_schedule_blocked_fault_configuration_ids(
             {"simulationId": str(empty_simulation_configuration.id)}, token
         )
-        (result, status) = response
 
         assert status == 200
         assert str(config.id) in result
@@ -63,10 +65,9 @@ class TestScheduleBlockedFaultConfiguration:
                 return str(first) == str(second)
             return first == second
 
-        response = impl.component.create_schedule_blocked_fault_configuration(
+        (result, status) = impl.component.create_schedule_blocked_fault_configuration(
             schedule_blocked_fault_configuration_data, token
         )
-        (result, status) = response
         assert status == 201
         assert result["id"]
         configs = ScheduleBlockedFaultConfiguration.select().where(
@@ -86,10 +87,9 @@ class TestScheduleBlockedFaultConfiguration:
             **schedule_blocked_fault_configuration_data
         )
 
-        response = impl.component.get_schedule_blocked_fault_configuration(
+        (result, status) = impl.component.get_schedule_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
         assert status == 200
         assert str(config.id) == result["id"]
         assert str(config.updated_at) == result["updated_at"]
@@ -111,10 +111,9 @@ class TestScheduleBlockedFaultConfiguration:
         config = ScheduleBlockedFaultConfiguration.create(
             **schedule_blocked_fault_configuration_data
         )
-        response = impl.component.delete_schedule_blocked_fault_configuration(
+        (result, status) = impl.component.delete_schedule_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
         assert status == 204
         assert result == "Deleted schedule-blocked-fault configuration"
         assert (
@@ -128,10 +127,9 @@ class TestScheduleBlockedFaultConfiguration:
         token,
     ):
         object_id = uuid.uuid4()
-        response = impl.component.delete_schedule_blocked_fault_configuration(
+        (result, status) = impl.component.delete_schedule_blocked_fault_configuration(
             {"identifier": object_id}, token
         )
-        (result, status) = response
         assert status == 404
         assert result == "Id not found"
 
@@ -148,10 +146,9 @@ class TestScheduleBlockedFaultConfiguration:
             simulation_configuration=empty_simulation_configuration,
             schedule_blocked_fault_configuration=config,
         )
-        response = impl.component.delete_schedule_blocked_fault_configuration(
+        (result, status) = impl.component.delete_schedule_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
         assert status == 400
         assert (
             result

--- a/tests/implementor/test_impl_simulation.py
+++ b/tests/implementor/test_impl_simulation.py
@@ -7,8 +7,12 @@ from src.implementor.models import Run, SimulationConfiguration, Token
 from src.spawner.spawner import SpawnerConfiguration
 
 
+# pylint: disable=duplicate-code
 class TestSimulationImplementor:
-    """Tests for SimulationImplementor"""
+    """
+    Tests for correct functionality of simulation configuration endpoint
+    if the input data is valid.
+    """
 
     def test_get_all_simulation_ids(self, token):
         simulation = SimulationConfiguration()

--- a/tests/implementor/test_impl_spawner.py
+++ b/tests/implementor/test_impl_spawner.py
@@ -72,10 +72,10 @@ class TestSpawnerConfiguration:
     def test_get_all_spawner_configuration_ids(self, token, spawner_configuration_data):
         config = SpawnerConfiguration.create(**spawner_configuration_data)
 
-        response = impl.component.get_all_spawner_configuration_ids(
+        (result, status) = impl.component.get_all_spawner_configuration_ids(
             {"simulationId": None}, token
         )
-        (result, status) = response
+
         assert status == 200
         assert str(config.id) in result
 
@@ -92,20 +92,19 @@ class TestSpawnerConfiguration:
             spawner_configuration=config,
         )
 
-        response = impl.component.get_all_spawner_configuration_ids(
+        (result, status) = impl.component.get_all_spawner_configuration_ids(
             {"simulationId": str(empty_simulation_configuration.id)}, token
         )
-        (result, status) = response
 
         assert status == 200
         assert str(config.id) in result
         assert str(another_config.id) not in result
 
     def test_create_spawner_configuration(self, token, spawner_configuration_data):
-        response = impl.component.create_spawner_configuration(
+        (result, status) = impl.component.create_spawner_configuration(
             spawner_configuration_data, token
         )
-        (result, status) = response
+
         assert status == 201
         assert result["id"]
         configs = SpawnerConfiguration.select().where(
@@ -124,9 +123,9 @@ class TestSpawnerConfiguration:
         self,
         token,
     ):
-        response = impl.component.create_spawner_configuration(
+        (result, status) = impl.component.create_spawner_configuration(
             {"schedule": ["00000000-0000-0000-0000-000000000000"]}, token
         )
-        (result, status) = response
+
         assert status == 404
         assert result == "Schedule not found"

--- a/tests/implementor/test_impl_spawner.py
+++ b/tests/implementor/test_impl_spawner.py
@@ -72,7 +72,9 @@ class TestSpawnerConfiguration:
     def test_get_all_spawner_configuration_ids(self, token, spawner_configuration_data):
         config = SpawnerConfiguration.create(**spawner_configuration_data)
 
-        response = impl.component.get_all_spawner_configuration_ids({}, token)
+        response = impl.component.get_all_spawner_configuration_ids(
+            {"simulationId": None}, token
+        )
         (result, status) = response
         assert status == 200
         assert str(config.id) in result

--- a/tests/implementor/test_impl_spawner.py
+++ b/tests/implementor/test_impl_spawner.py
@@ -6,8 +6,12 @@ from src.spawner.spawner import (
 )
 
 
+# pylint: disable=duplicate-code
 class TestSpawnerConfiguration:
-    """Tests for SpawnerConfiguration"""
+    """
+    Tests for correct functionality of spawner configuration endpoint
+    if the input data is valid.
+    """
 
     def test_get_single_spawner_configuration(self, token, spawner_configuration):
         result, status = impl.component.get_spawner_configuration(
@@ -73,7 +77,7 @@ class TestSpawnerConfiguration:
         assert status == 200
         assert str(config.id) in result
 
-    def test_get_all_spawner_configuration_ids(
+    def test_get_all_spawner_configuration_ids_with_simulation(
         self,
         token,
         spawner_configuration_data,

--- a/tests/implementor/test_impl_track_blocked_fault.py
+++ b/tests/implementor/test_impl_track_blocked_fault.py
@@ -7,7 +7,13 @@ from src.fault_injector.fault_configurations.track_blocked_fault_configuration i
 )
 
 
+# pylint: disable=duplicate-code
 class TestTrackBlockedFaultConfiguration:
+    """
+    Tests for correct functionality of track blocked fault configuration endpoint
+    if the input data is valid.
+    """
+
     def test_get_all_track_blocked_fault_configuration_ids(
         self, token, track_blocked_fault_configuration_data
     ):
@@ -22,7 +28,7 @@ class TestTrackBlockedFaultConfiguration:
         assert status == 200
         assert str(config.id) in result
 
-    def test_get_all_track_blocked_fault_configuration_ids(
+    def test_get_all_track_blocked_fault_configuration_ids_with_simulation(
         self,
         token,
         track_blocked_fault_configuration_data,
@@ -49,7 +55,7 @@ class TestTrackBlockedFaultConfiguration:
         assert str(another_config.id) not in result
 
     def test_create_track_blocked_fault_configuration(
-        token, track_blocked_fault_configuration_data
+        self, token, track_blocked_fault_configuration_data
     ):
         response = impl.component.create_track_blocked_fault_configuration(
             track_blocked_fault_configuration_data, token
@@ -112,7 +118,6 @@ class TestTrackBlockedFaultConfiguration:
     def test_delete_track_blocked_fault_configuration_not_found(
         self,
         token,
-        track_blocked_fault_configuration_data,
     ):
         object_id = uuid.uuid4()
         response = impl.component.delete_track_blocked_fault_configuration(

--- a/tests/implementor/test_impl_track_blocked_fault.py
+++ b/tests/implementor/test_impl_track_blocked_fault.py
@@ -21,10 +21,10 @@ class TestTrackBlockedFaultConfiguration:
             **track_blocked_fault_configuration_data
         )
 
-        response = impl.component.get_all_track_blocked_fault_configuration_ids(
+        (result, status) = impl.component.get_all_track_blocked_fault_configuration_ids(
             {}, token
         )
-        (result, status) = response
+
         assert status == 200
         assert str(config.id) in result
 
@@ -45,10 +45,9 @@ class TestTrackBlockedFaultConfiguration:
             track_blocked_fault_configuration=config,
         )
 
-        response = impl.component.get_all_track_blocked_fault_configuration_ids(
+        (result, status) = impl.component.get_all_track_blocked_fault_configuration_ids(
             {"simulationId": str(empty_simulation_configuration.id)}, token
         )
-        (result, status) = response
 
         assert status == 200
         assert str(config.id) in result
@@ -57,10 +56,10 @@ class TestTrackBlockedFaultConfiguration:
     def test_create_track_blocked_fault_configuration(
         self, token, track_blocked_fault_configuration_data
     ):
-        response = impl.component.create_track_blocked_fault_configuration(
+        (result, status) = impl.component.create_track_blocked_fault_configuration(
             track_blocked_fault_configuration_data, token
         )
-        (result, status) = response
+
         assert status == 201
         assert result["id"]
         configs = TrackBlockedFaultConfiguration.select().where(
@@ -78,10 +77,10 @@ class TestTrackBlockedFaultConfiguration:
             **track_blocked_fault_configuration_data
         )
 
-        response = impl.component.get_track_blocked_fault_configuration(
+        (result, status) = impl.component.get_track_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 200
         assert str(config.id) == result["id"]
         assert str(config.updated_at) == result["updated_at"]
@@ -103,10 +102,10 @@ class TestTrackBlockedFaultConfiguration:
         config = TrackBlockedFaultConfiguration.create(
             **track_blocked_fault_configuration_data
         )
-        response = impl.component.delete_track_blocked_fault_configuration(
+        (result, status) = impl.component.delete_track_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 204
         assert result == "Deleted track-blocked-fault configuration"
         assert (
@@ -120,10 +119,10 @@ class TestTrackBlockedFaultConfiguration:
         token,
     ):
         object_id = uuid.uuid4()
-        response = impl.component.delete_track_blocked_fault_configuration(
+        (result, status) = impl.component.delete_track_blocked_fault_configuration(
             {"identifier": object_id}, token
         )
-        (result, status) = response
+
         assert status == 404
         assert result == "Id not found"
 
@@ -140,10 +139,10 @@ class TestTrackBlockedFaultConfiguration:
             simulation_configuration=empty_simulation_configuration,
             track_blocked_fault_configuration=config,
         )
-        response = impl.component.delete_track_blocked_fault_configuration(
+        (result, status) = impl.component.delete_track_blocked_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 400
         assert (
             result

--- a/tests/implementor/test_impl_track_speed_limit_fault.py
+++ b/tests/implementor/test_impl_track_speed_limit_fault.py
@@ -21,10 +21,11 @@ class TestTrackSpeedLimitFaultConfiguration:
             **track_speed_limit_fault_configuration_data
         )
 
-        response = impl.component.get_all_track_speed_limit_fault_configuration_ids(
-            {}, token
-        )
-        (result, status) = response
+        (
+            result,
+            status,
+        ) = impl.component.get_all_track_speed_limit_fault_configuration_ids({}, token)
+
         assert status == 200
         assert str(config.id) in result
 
@@ -45,10 +46,12 @@ class TestTrackSpeedLimitFaultConfiguration:
             track_speed_limit_fault_configuration=config,
         )
 
-        response = impl.component.get_all_track_speed_limit_fault_configuration_ids(
+        (
+            result,
+            status,
+        ) = impl.component.get_all_track_speed_limit_fault_configuration_ids(
             {"simulationId": str(empty_simulation_configuration.id)}, token
         )
-        (result, status) = response
 
         assert status == 200
         assert str(config.id) in result
@@ -57,10 +60,10 @@ class TestTrackSpeedLimitFaultConfiguration:
     def test_create_track_speed_limit_fault_configuration(
         self, token, track_speed_limit_fault_configuration_data
     ):
-        response = impl.component.create_track_speed_limit_fault_configuration(
+        (result, status) = impl.component.create_track_speed_limit_fault_configuration(
             track_speed_limit_fault_configuration_data, token
         )
-        (result, status) = response
+
         assert status == 201
         assert result["id"]
         configs = TrackSpeedLimitFaultConfiguration.select().where(
@@ -80,10 +83,10 @@ class TestTrackSpeedLimitFaultConfiguration:
             **track_speed_limit_fault_configuration_data
         )
 
-        response = impl.component.get_track_speed_limit_fault_configuration(
+        (result, status) = impl.component.get_track_speed_limit_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 200
         assert str(config.id) == result["id"]
         assert str(config.updated_at) == result["updated_at"]
@@ -105,10 +108,10 @@ class TestTrackSpeedLimitFaultConfiguration:
         config = TrackSpeedLimitFaultConfiguration.create(
             **track_speed_limit_fault_configuration_data
         )
-        response = impl.component.delete_track_speed_limit_fault_configuration(
+        (result, status) = impl.component.delete_track_speed_limit_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 204
         assert result == "Deleted track-speed-limit-fault configuration"
         assert (
@@ -125,10 +128,10 @@ class TestTrackSpeedLimitFaultConfiguration:
         track_speed_limit_fault_configuration_data,
     ):
         object_id = uuid.uuid4()
-        response = impl.component.delete_track_speed_limit_fault_configuration(
+        (result, status) = impl.component.delete_track_speed_limit_fault_configuration(
             {"identifier": object_id}, token
         )
-        (result, status) = response
+
         assert status == 404
         assert result == "Id not found"
 
@@ -145,10 +148,10 @@ class TestTrackSpeedLimitFaultConfiguration:
             simulation_configuration=empty_simulation_configuration,
             track_speed_limit_fault_configuration=config,
         )
-        response = impl.component.delete_track_speed_limit_fault_configuration(
+        (result, status) = impl.component.delete_track_speed_limit_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 400
         assert (
             result

--- a/tests/implementor/test_impl_track_speed_limit_fault.py
+++ b/tests/implementor/test_impl_track_speed_limit_fault.py
@@ -7,8 +7,12 @@ from src.fault_injector.fault_configurations.track_speed_limit_fault_configurati
 )
 
 
+# pylint: disable=duplicate-code
 class TestTrackSpeedLimitFaultConfiguration:
-    """Test for TrackSpeedLimitFaultConfiguration"""
+    """
+    Tests for correct functionality of track speed limit fault configuration endpoint
+    if the input data is valid.
+    """
 
     def test_get_all_track_speed_limit_fault_configuration_ids(
         self, token, track_speed_limit_fault_configuration_data

--- a/tests/implementor/test_impl_train_prio_fault.py
+++ b/tests/implementor/test_impl_train_prio_fault.py
@@ -21,8 +21,10 @@ class TestTrainPrioFaultConfiguration:
             **train_prio_fault_configuration_data
         )
 
-        response = impl.component.get_all_train_prio_fault_configuration_ids({}, token)
-        (result, status) = response
+        (result, status) = impl.component.get_all_train_prio_fault_configuration_ids(
+            {}, token
+        )
+
         assert status == 200
         assert str(config.id) in result
 
@@ -43,10 +45,9 @@ class TestTrainPrioFaultConfiguration:
             train_prio_fault_configuration=config,
         )
 
-        response = impl.component.get_all_train_prio_fault_configuration_ids(
+        (result, status) = impl.component.get_all_train_prio_fault_configuration_ids(
             {"simulationId": str(empty_simulation_configuration.id)}, token
         )
-        (result, status) = response
 
         assert status == 200
         assert str(config.id) in result
@@ -55,10 +56,10 @@ class TestTrainPrioFaultConfiguration:
     def test_create_train_prio_fault_configuration(
         self, token, train_prio_fault_configuration_data
     ):
-        response = impl.component.create_train_prio_fault_configuration(
+        (result, status) = impl.component.create_train_prio_fault_configuration(
             train_prio_fault_configuration_data, token
         )
-        (result, status) = response
+
         assert status == 201
         assert result["id"]
         configs = TrainPrioFaultConfiguration.select().where(
@@ -76,10 +77,10 @@ class TestTrainPrioFaultConfiguration:
             **train_prio_fault_configuration_data
         )
 
-        response = impl.component.get_train_prio_fault_configuration(
+        (result, status) = impl.component.get_train_prio_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 200
         assert str(config.id) == result["id"]
         assert str(config.updated_at) == result["updated_at"]
@@ -101,10 +102,10 @@ class TestTrainPrioFaultConfiguration:
         config = TrainPrioFaultConfiguration.create(
             **train_prio_fault_configuration_data
         )
-        response = impl.component.delete_train_prio_fault_configuration(
+        (result, status) = impl.component.delete_train_prio_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 204
         assert result == "Deleted train-prio-fault configuration"
         assert (
@@ -118,10 +119,10 @@ class TestTrainPrioFaultConfiguration:
         token,
     ):
         object_id = uuid.uuid4()
-        response = impl.component.delete_train_prio_fault_configuration(
+        (result, status) = impl.component.delete_train_prio_fault_configuration(
             {"identifier": object_id}, token
         )
-        (result, status) = response
+
         assert status == 404
         assert result == "Id not found"
 
@@ -138,10 +139,10 @@ class TestTrainPrioFaultConfiguration:
             simulation_configuration=empty_simulation_configuration,
             train_prio_fault_configuration=config,
         )
-        response = impl.component.delete_train_prio_fault_configuration(
+        (result, status) = impl.component.delete_train_prio_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 400
         assert (
             result

--- a/tests/implementor/test_impl_train_prio_fault.py
+++ b/tests/implementor/test_impl_train_prio_fault.py
@@ -7,7 +7,13 @@ from src.fault_injector.fault_configurations.train_prio_fault_configuration impo
 )
 
 
+# pylint: disable=duplicate-code
 class TestTrainPrioFaultConfiguration:
+    """
+    Tests for correct functionality of train prio fault configuration endpoint
+    if the input data is valid.
+    """
+
     def test_get_all_train_prio_fault_configuration_ids(
         self, token, train_prio_fault_configuration_data
     ):
@@ -20,7 +26,7 @@ class TestTrainPrioFaultConfiguration:
         assert status == 200
         assert str(config.id) in result
 
-    def test_get_all_train_prio_fault_configuration_ids(
+    def test_get_all_train_prio_fault_configuration_ids_with_simulation(
         self,
         token,
         train_prio_fault_configuration_data,
@@ -47,7 +53,7 @@ class TestTrainPrioFaultConfiguration:
         assert str(another_config.id) not in result
 
     def test_create_train_prio_fault_configuration(
-        token, train_prio_fault_configuration_data
+        self, token, train_prio_fault_configuration_data
     ):
         response = impl.component.create_train_prio_fault_configuration(
             train_prio_fault_configuration_data, token
@@ -110,7 +116,6 @@ class TestTrainPrioFaultConfiguration:
     def test_delete_train_prio_fault_configuration_not_found(
         self,
         token,
-        train_prio_fault_configuration_data,
     ):
         object_id = uuid.uuid4()
         response = impl.component.delete_train_prio_fault_configuration(

--- a/tests/implementor/test_impl_train_speed_fault.py
+++ b/tests/implementor/test_impl_train_speed_fault.py
@@ -21,8 +21,10 @@ class TestTrainSpeedFaultConfiguration:
             **train_speed_fault_configuration_data
         )
 
-        response = impl.component.get_all_train_speed_fault_configuration_ids({}, token)
-        (result, status) = response
+        (result, status) = impl.component.get_all_train_speed_fault_configuration_ids(
+            {}, token
+        )
+
         assert status == 200
         assert str(config.id) in result
 
@@ -43,10 +45,9 @@ class TestTrainSpeedFaultConfiguration:
             train_speed_fault_configuration=config,
         )
 
-        response = impl.component.get_all_train_speed_fault_configuration_ids(
+        (result, status) = impl.component.get_all_train_speed_fault_configuration_ids(
             {"simulationId": str(empty_simulation_configuration.id)}, token
         )
-        (result, status) = response
 
         assert status == 200
         assert str(config.id) in result
@@ -55,10 +56,10 @@ class TestTrainSpeedFaultConfiguration:
     def test_create_train_speed_fault_configuration(
         self, token, train_speed_fault_configuration_data
     ):
-        response = impl.component.create_train_speed_fault_configuration(
+        (result, status) = impl.component.create_train_speed_fault_configuration(
             train_speed_fault_configuration_data, token
         )
-        (result, status) = response
+
         assert status == 201
         assert result["id"]
         configs = TrainSpeedFaultConfiguration.select().where(
@@ -76,10 +77,10 @@ class TestTrainSpeedFaultConfiguration:
             **train_speed_fault_configuration_data
         )
 
-        response = impl.component.get_train_speed_fault_configuration(
+        (result, status) = impl.component.get_train_speed_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 200
         assert str(config.id) == result["id"]
         assert str(config.updated_at) == result["updated_at"]
@@ -101,10 +102,10 @@ class TestTrainSpeedFaultConfiguration:
         config = TrainSpeedFaultConfiguration.create(
             **train_speed_fault_configuration_data
         )
-        response = impl.component.delete_train_speed_fault_configuration(
+        (result, status) = impl.component.delete_train_speed_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 204
         assert result == "Deleted train-speed-fault configuration"
         assert (
@@ -118,10 +119,10 @@ class TestTrainSpeedFaultConfiguration:
         token,
     ):
         object_id = uuid.uuid4()
-        response = impl.component.delete_train_speed_fault_configuration(
+        (result, status) = impl.component.delete_train_speed_fault_configuration(
             {"identifier": object_id}, token
         )
-        (result, status) = response
+
         assert status == 404
         assert result == "Id not found"
 
@@ -138,10 +139,10 @@ class TestTrainSpeedFaultConfiguration:
             simulation_configuration=empty_simulation_configuration,
             train_speed_fault_configuration=config,
         )
-        response = impl.component.delete_train_speed_fault_configuration(
+        (result, status) = impl.component.delete_train_speed_fault_configuration(
             {"identifier": str(config.id)}, token
         )
-        (result, status) = response
+
         assert status == 400
         assert (
             result

--- a/tests/implementor/test_impl_train_speed_fault.py
+++ b/tests/implementor/test_impl_train_speed_fault.py
@@ -7,7 +7,13 @@ from src.fault_injector.fault_configurations.train_speed_fault_configuration imp
 )
 
 
+# pylint: disable=duplicate-code
 class TestTrainSpeedFaultConfiguration:
+    """
+    Tests for correct functionality of train speed fault configuration endpoint
+    if the input data is valid.
+    """
+
     def test_get_all_train_speed_fault_configuration_ids(
         self, token, train_speed_fault_configuration_data
     ):
@@ -20,7 +26,7 @@ class TestTrainSpeedFaultConfiguration:
         assert status == 200
         assert str(config.id) in result
 
-    def test_get_all_train_speed_fault_configuration_ids(
+    def test_get_all_train_speed_fault_configuration_ids_with_simulation(
         self,
         token,
         train_speed_fault_configuration_data,
@@ -47,7 +53,7 @@ class TestTrainSpeedFaultConfiguration:
         assert str(another_config.id) not in result
 
     def test_create_train_speed_fault_configuration(
-        token, train_speed_fault_configuration_data
+        self, token, train_speed_fault_configuration_data
     ):
         response = impl.component.create_train_speed_fault_configuration(
             train_speed_fault_configuration_data, token
@@ -110,7 +116,6 @@ class TestTrainSpeedFaultConfiguration:
     def test_delete_train_speed_fault_configuration_not_found(
         self,
         token,
-        train_speed_fault_configuration_data,
     ):
         object_id = uuid.uuid4()
         response = impl.component.delete_train_speed_fault_configuration(

--- a/tests/implementor/test_table_token.py
+++ b/tests/implementor/test_table_token.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-import marshmallow as marsh
 import peewee
 import pytest
 


### PR DESCRIPTION
Fixes #574 

Enable lint for implementor tests.
Fix lint.

## PR checklist

- [x] Acceptance criteria fulfilled
- [x] Additional features are tested
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
