### PR TITLE
Enable lint in fault injector tests

### DIFF
--- a/tests/fault_injector/conftest.py
+++ b/tests/fault_injector/conftest.py
@@ -50,6 +50,8 @@ def event_bus(run):
 
 
 class MockRouteController:
+    """Mock up for RouteController"""
+
     method_calls: int = 0
 
     def recalculate_all_routes(self):
@@ -81,12 +83,16 @@ def platform() -> Platform:
     return Platform("fancy-platform", platform_id="platform-1", edge_id="fancy-edge")
 
 
+# pylint: disable=protected-access
 @pytest.fixture
 def track(edge, edge_re):
     track = Track(edge, edge_re)
     edge._track = track
     edge_re._track = track
     return track
+
+
+# pylint: enable=protected-access
 
 
 @pytest.fixture
@@ -116,13 +122,17 @@ def combine_train_and_wrapper(
     return train, simulation_object_updater
 
 
+# pylint: disable=invalid-name
 @pytest.fixture
 def train_add(monkeypatch):
-    def add_train(identifier, routeID=None, typeID=None):
+    def add_train(identifier, typeID=None):
         assert identifier is not None
         assert typeID is not None
 
     monkeypatch.setattr(vehicle, "add", add_train)
+
+
+# pylint: enable=invalid-name
 
 
 @pytest.fixture

--- a/tests/fault_injector/conftest.py
+++ b/tests/fault_injector/conftest.py
@@ -122,17 +122,19 @@ def combine_train_and_wrapper(
     return train, simulation_object_updater
 
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, unused-argument
+# disabling invalid-name allows the names routeID and typeID, despite the fact,
+# that they don't follow snake_case
 @pytest.fixture
 def train_add(monkeypatch):
-    def add_train(identifier, typeID=None):
+    def add_train(identifier, routeID=None, typeID=None):
         assert identifier is not None
         assert typeID is not None
 
     monkeypatch.setattr(vehicle, "add", add_train)
 
 
-# pylint: enable=invalid-name
+# pylint: enable=invalid-name, unused-argument
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #578 

Enables the linter in tests for the fault injector component and fixes appearing lint errors.

## PR checklist

- [ ] Acceptance criteria fulfilled
- [ ] Additional features are tested
- [ ] Docs (code, wiki & diagrams) updated
- [ ] Breaking changes anounced
- [ ] Added classes that inherit from `BaseModel` to `src.constants.tables`
- [ ] Dev-branch has been merged into local branch to resolve conflicts
- [ ] Tests and linter have passed AFTER local merge
- [ ] Another dev reviewed and approved
